### PR TITLE
Remove author anotation

### DIFF
--- a/app/common/src/main/scala/io/scalajs/nodejs/Assert.scala
+++ b/app/common/src/main/scala/io/scalajs/nodejs/Assert.scala
@@ -12,7 +12,6 @@ import scala.scalajs.js.annotation.JSImport
   *
   * The API for the assert module is Locked. This means that there will be no additions or changes to any of the
   * methods implemented and exposed by the module.
-  * @author lawrence.daniels@gmail.com
   */
 @js.native
 trait Assert extends IEventEmitter {
@@ -134,7 +133,6 @@ trait Assert extends IEventEmitter {
 
 /**
   * Assert Singleton
-  * @author lawrence.daniels@gmail.com
   */
 @js.native
 @JSImport("assert", JSImport.Namespace)

--- a/app/common/src/main/scala/io/scalajs/nodejs/Console.scala
+++ b/app/common/src/main/scala/io/scalajs/nodejs/Console.scala
@@ -17,7 +17,6 @@ import scala.scalajs.js.annotation.JSImport
   * used without calling require('console').</li>
   * </ul>
   * @see https://nodejs.org/dist/latest-v8.x/docs/api/console.html
-  * @author lawrence.daniels@gmail.com
   */
 @js.native
 @JSImport("console", "Console")
@@ -150,7 +149,6 @@ class Console(stdout: Writable, stderr: Writable = js.native) extends js.Object 
   *                   inspecting large complicated objects. Defaults to 2. To make it recurse indefinitely, pass null.
   * @param colors     if true, then the output will be styled with ANSI color codes. Defaults to false. Colors are customizable;
   *                   see customizing util.inspect() colors.
-  * @author lawrence.daniels@gmail.com
   */
 class ConsoleDirOptions(var showHidden: js.UndefOr[Boolean] = js.undefined,
                         var depth: js.UndefOr[Int] = js.undefined,

--- a/app/common/src/main/scala/io/scalajs/nodejs/Error.scala
+++ b/app/common/src/main/scala/io/scalajs/nodejs/Error.scala
@@ -10,7 +10,6 @@ import scala.scalajs.js.annotation.{JSGlobal, JSImport}
   * Stack traces are dependent on V8's stack trace API. Stack traces extend only to either (a) the
   * beginning of synchronous code execution, or (b) the number of frames given by the property
   * Error.stackTraceLimit, whichever is smaller.
-  * @author lawrence.daniels@gmail.com
   */
 @js.native
 @JSImport("errors", "Error")
@@ -33,7 +32,6 @@ class Error(message0: String = js.native) extends js.Object {
 
 /**
   * Error Singleton
-  * @author lawrence.daniels@gmail.com
   */
 @js.native
 @JSGlobal

--- a/app/common/src/main/scala/io/scalajs/nodejs/Global.scala
+++ b/app/common/src/main/scala/io/scalajs/nodejs/Global.scala
@@ -8,7 +8,6 @@ import scala.scalajs.js
   * In browsers, the top-level scope is the global scope. That means that in browsers if you're in the global scope var
   * something will define a global variable. In Node.js this is different. The top-level scope is not the global scope;
   * var something inside an Node.js module will be local to that module.
-  * @author lawrence.daniels@gmail.com
   */
 @js.native
 trait Global extends js.Object {

--- a/app/common/src/main/scala/io/scalajs/nodejs/Module.scala
+++ b/app/common/src/main/scala/io/scalajs/nodejs/Module.scala
@@ -7,7 +7,6 @@ import scala.scalajs.js.annotation.JSGlobal
   * In each module, the module free variable is a reference to the object representing the current module.
   * For convenience, module.exports is also accessible via the exports module-global. module isn't actually
   * a global but rather local to each module.
-  * @author lawrence.daniels@gmail.com
   * @see [[https://nodejs.org/api/modules.html#modules_the_module_object]]
   */
 @js.native
@@ -64,7 +63,6 @@ trait Module extends js.Object {
 
 /**
   * Module Companion
-  * @author lawrence.daniels@gmail.com
   */
 object Module {
 

--- a/app/common/src/main/scala/io/scalajs/nodejs/Process.scala
+++ b/app/common/src/main/scala/io/scalajs/nodejs/Process.scala
@@ -11,7 +11,6 @@ import scala.scalajs.js.UndefOr
 
 /**
   * The process object is a global object and can be accessed from anywhere. It is an instance of EventEmitter.
-  * @author lawrence.daniels@gmail.com
   */
 @js.native
 trait Process extends IEventEmitter {
@@ -406,7 +405,6 @@ trait Process extends IEventEmitter {
 
 /**
   * Process Object Companion
-  * @author lawrence.daniels@gmail.com
   */
 object Process {
 

--- a/app/common/src/main/scala/io/scalajs/nodejs/StringDecoder.scala
+++ b/app/common/src/main/scala/io/scalajs/nodejs/StringDecoder.scala
@@ -9,7 +9,6 @@ import scala.scalajs.js.annotation.JSImport
 /**
   * To use this module, do require('string_decoder'). StringDecoder decodes a buffer to a string. It is a simple
   * interface to [[Buffer.toString()]] but provides additional support for utf8.
-  * @author lawrence.daniels@gmail.com
   */
 @js.native
 @JSImport("string_decoder", "StringDecoder")

--- a/app/common/src/main/scala/io/scalajs/nodejs/SystemError.scala
+++ b/app/common/src/main/scala/io/scalajs/nodejs/SystemError.scala
@@ -6,7 +6,6 @@ import scala.scalajs.js.|
 
 /**
   * System Error
-  * @author lawrence.daniels@gmail.com
   */
 @js.native
 @JSImport("errors", "SystemError")
@@ -52,7 +51,6 @@ class SystemError(message0: String = js.native) extends Error(message0) {
 
 /**
   * System Error Singleton
-  * @author lawrence.daniels@gmail.com
   */
 @js.native
 @JSImport("errors", JSImport.Namespace)

--- a/app/common/src/main/scala/io/scalajs/nodejs/buffer/Buffer.scala
+++ b/app/common/src/main/scala/io/scalajs/nodejs/buffer/Buffer.scala
@@ -20,7 +20,6 @@ import scala.scalajs.js.|
   *
   * The Buffer class is a global within Node.js, making it unlikely that one would need to ever use require('buffer').
   * @see https://nodejs.org/api/buffer.html
-  * @author lawrence.daniels@gmail.com
   */
 @js.native
 @JSImport("buffer", "Buffer")

--- a/app/common/src/main/scala/io/scalajs/nodejs/buffer/SlowBuffer.scala
+++ b/app/common/src/main/scala/io/scalajs/nodejs/buffer/SlowBuffer.scala
@@ -14,7 +14,6 @@ import scala.scalajs.js.annotation.JSImport
   * amount of time, it may be appropriate to create an un-pooled Buffer instance using SlowBuffer then copy
   * out the relevant bits.
   * @see https://nodejs.org/api/buffer.html#buffer_class_slowbuffer
-  * @author lawrence.daniels@gmail.com
   */
 @deprecated("Use Buffer.allocUnsafeSlow() instead.", since = "6.0.0")
 @js.native

--- a/app/common/src/main/scala/io/scalajs/nodejs/buffer/package.scala
+++ b/app/common/src/main/scala/io/scalajs/nodejs/buffer/package.scala
@@ -4,7 +4,6 @@ import scala.scalajs.js
 
 /**
   * buffer package object
-  * @author lawrence.daniels@gmail.com
   */
 package object buffer {
 
@@ -14,7 +13,6 @@ package object buffer {
 
   /**
     * Buffer Extensions
-    * @author lawrence.daniels@gmail.com
     */
   implicit class BufferExtensions(val buffer: Buffer) extends AnyVal {
 

--- a/app/common/src/main/scala/io/scalajs/nodejs/child_process/ForkOptions.scala
+++ b/app/common/src/main/scala/io/scalajs/nodejs/child_process/ForkOptions.scala
@@ -19,7 +19,6 @@ import scala.scalajs.js
   *                 value 'ipc' or an error will be thrown. For instance [0, 1, 2, 'ipc'].
   * @param uid      <Number> Sets the user identity of the process. (See setuid(2).)
   * @param gid      <Number> Sets the group identity of the process. (See setgid(2).)
-  * @author lawrence.daniels@gmail.com
   */
 class ForkOptions(val cwd: js.UndefOr[String] = js.undefined,
                   val env: js.Any = js.undefined,

--- a/app/common/src/main/scala/io/scalajs/nodejs/child_process/SpawnOptions.scala
+++ b/app/common/src/main/scala/io/scalajs/nodejs/child_process/SpawnOptions.scala
@@ -18,7 +18,6 @@ import scala.scalajs.js.|
   * @param shell    <Boolean> | <String> If true, runs command inside of a shell.
   *                 Uses '/bin/sh' on UNIX, and 'cmd.exe' on Windows. A different shell can be specified as a string.
   *                 The shell should understand the -c switch on UNIX, or /d /s /c on Windows. Defaults to false (no shell).
-  * @author lawrence.daniels@gmail.com
   */
 class SpawnOptions(
     val cwd: js.UndefOr[String] = js.undefined,

--- a/app/common/src/main/scala/io/scalajs/nodejs/cluster/Address.scala
+++ b/app/common/src/main/scala/io/scalajs/nodejs/cluster/Address.scala
@@ -4,7 +4,6 @@ import scala.scalajs.js
 
 /**
   * Address
-  * @author lawrence.daniels@gmail.com
   */
 @js.native
 trait Address extends js.Object {

--- a/app/common/src/main/scala/io/scalajs/nodejs/cluster/Cluster.scala
+++ b/app/common/src/main/scala/io/scalajs/nodejs/cluster/Cluster.scala
@@ -10,7 +10,6 @@ import scala.scalajs.js.annotation.JSImport
   * sometimes want to launch a cluster of Node.js processes to handle the load.
   *
   * The cluster module allows you to easily create child processes that all share server ports.
-  * @author lawrence.daniels@gmail.com
   */
 @js.native
 trait Cluster extends IEventEmitter {
@@ -113,7 +112,6 @@ trait Cluster extends IEventEmitter {
 
 /**
   * Cluster Singleton
-  * @author lawrence.daniels@gmail.com
   */
 @js.native
 @JSImport("cluster", JSImport.Namespace)

--- a/app/common/src/main/scala/io/scalajs/nodejs/cluster/Worker.scala
+++ b/app/common/src/main/scala/io/scalajs/nodejs/cluster/Worker.scala
@@ -8,7 +8,6 @@ import scala.scalajs.js
 /**
   * A Worker object contains all public information and method about a worker. In the master it can be obtained using
   * cluster.workers. In a worker it can be obtained using cluster.worker.
-  * @author lawrence.daniels@gmail.com
   */
 @js.native
 trait Worker extends IEventEmitter {

--- a/app/common/src/main/scala/io/scalajs/nodejs/crypto/Cipher.scala
+++ b/app/common/src/main/scala/io/scalajs/nodejs/crypto/Cipher.scala
@@ -14,7 +14,6 @@ import scala.scalajs.js
   * </ul>
   * The crypto.createCipher() or crypto.createCipheriv() methods are used to create Cipher instances. Cipher objects
   * are not to be created directly using the new keyword.
-  * @author lawrence.daniels@gmail.com
   */
 @js.native
 trait Cipher extends IDuplex {

--- a/app/common/src/main/scala/io/scalajs/nodejs/crypto/Crypto.scala
+++ b/app/common/src/main/scala/io/scalajs/nodejs/crypto/Crypto.scala
@@ -10,7 +10,6 @@ import scala.scalajs.js.|
   * The crypto module provides cryptographic functionality that includes a set of wrappers
   * for OpenSSL's hash, HMAC, cipher, decipher, sign and verify functions.
   * @see https://nodejs.org/dist/latest-v7.x/docs/api/crypto.html#crypto_crypto
-  * @author lawrence.daniels@gmail.com
   */
 @js.native
 trait Crypto extends js.Object {
@@ -145,7 +144,6 @@ trait Crypto extends js.Object {
 
 /**
   * Crypto Singleton
-  * @author lawrence.daniels@gmail.com
   */
 @js.native
 @JSImport("crypto", JSImport.Namespace)

--- a/app/common/src/main/scala/io/scalajs/nodejs/crypto/Decipher.scala
+++ b/app/common/src/main/scala/io/scalajs/nodejs/crypto/Decipher.scala
@@ -14,7 +14,6 @@ import scala.scalajs.js
   *
   * The crypto.createDecipher() or crypto.createDecipheriv() methods are used to create Decipher instances.
   * Decipher objects are not to be created directly using the new keyword.
-  * @author lawrence.daniels@gmail.com
   */
 @js.native
 trait Decipher extends IDuplex {

--- a/app/common/src/main/scala/io/scalajs/nodejs/crypto/Hash.scala
+++ b/app/common/src/main/scala/io/scalajs/nodejs/crypto/Hash.scala
@@ -13,7 +13,6 @@ import scala.scalajs.js
   * </ul>
   * The crypto.createHash() method is used to create Hash instances. Hash objects are not to be created directly using
   * the new keyword.
-  * @author lawrence.daniels@gmail.com
   */
 @js.native
 trait Hash extends IDuplex {

--- a/app/common/src/main/scala/io/scalajs/nodejs/crypto/Hmac.scala
+++ b/app/common/src/main/scala/io/scalajs/nodejs/crypto/Hmac.scala
@@ -14,7 +14,6 @@ import scala.scalajs.js
   *
   * The crypto.createHmac() method is used to create Hmac instances. Hmac objects are not to be created directly using
   * the new keyword.
-  * @author lawrence.daniels@gmail.com
   */
 @js.native
 trait Hmac extends IDuplex {

--- a/app/common/src/main/scala/io/scalajs/nodejs/crypto/Sign.scala
+++ b/app/common/src/main/scala/io/scalajs/nodejs/crypto/Sign.scala
@@ -14,7 +14,6 @@ import scala.scalajs.js
   *
   * The crypto.createSign() method is used to create Sign instances. Sign objects are not to be created directly using
   * the new keyword.
-  * @author lawrence.daniels@gmail.com
   */
 @js.native
 trait Sign extends IDuplex {

--- a/app/common/src/main/scala/io/scalajs/nodejs/crypto/Verify.scala
+++ b/app/common/src/main/scala/io/scalajs/nodejs/crypto/Verify.scala
@@ -13,7 +13,6 @@ import scala.scalajs.js
   * </ul>
   * The crypto.createSign() method is used to create Sign instances. Sign objects are not to be created directly using
   * the new keyword.
-  * @author lawrence.daniels@gmail.com
   */
 @js.native
 trait Verify extends IDuplex {

--- a/app/common/src/main/scala/io/scalajs/nodejs/dns/DNS.scala
+++ b/app/common/src/main/scala/io/scalajs/nodejs/dns/DNS.scala
@@ -13,7 +13,6 @@ import scala.scalajs.js.|
   * looking to perform name resolution in the same way that other applications on the same operating system behave
   * should use dns.lookup().
   * @see https://nodejs.org/api/dns.html
-  * @author lawrence.daniels@gmail.com
   */
 @js.native
 trait DNS extends js.Object {
@@ -236,7 +235,6 @@ trait DNS extends js.Object {
 
 /**
   * DNS Singleton
-  * @author lawrence.daniels@gmail.com
   */
 @js.native
 @JSImport("dns", JSImport.Namespace)

--- a/app/common/src/main/scala/io/scalajs/nodejs/dns/DnsOptions.scala
+++ b/app/common/src/main/scala/io/scalajs/nodejs/dns/DnsOptions.scala
@@ -11,7 +11,6 @@ import scala.scalajs.js
   *               ORing their values. See supported getaddrinfo flags for more information on supported flags.</li>
   * @param all    When true, the callback returns all resolved addresses in an array, otherwise returns a
   *               single address. Defaults to false.
-  * @author lawrence.daniels@gmail.com
   */
 class DnsOptions(var family: js.UndefOr[Int] = js.undefined,
                  var hints: js.UndefOr[Int] = js.undefined,

--- a/app/common/src/main/scala/io/scalajs/nodejs/dns/MX.scala
+++ b/app/common/src/main/scala/io/scalajs/nodejs/dns/MX.scala
@@ -10,7 +10,6 @@ import scala.scalajs.js
   * priority: 10
   * }
   * </pre>
-  * @author lawrence.daniels@gmail.com
   */
 @js.native
 trait MX extends js.Object {

--- a/app/common/src/main/scala/io/scalajs/nodejs/dns/NAPTR.scala
+++ b/app/common/src/main/scala/io/scalajs/nodejs/dns/NAPTR.scala
@@ -14,7 +14,6 @@ import scala.scalajs.js
   * preference: 100
   * }
   * </pre>
-  * @author lawrence.daniels@gmail.com
   */
 @js.native
 trait NAPTR extends js.Object {

--- a/app/common/src/main/scala/io/scalajs/nodejs/dns/SOA.scala
+++ b/app/common/src/main/scala/io/scalajs/nodejs/dns/SOA.scala
@@ -15,7 +15,6 @@ import scala.scalajs.js
   * minttl: 3600
   * }
   * </pre>
-  * @author lawrence.daniels@gmail.com
   */
 @js.native
 trait SOA extends js.Object {

--- a/app/common/src/main/scala/io/scalajs/nodejs/dns/package.scala
+++ b/app/common/src/main/scala/io/scalajs/nodejs/dns/package.scala
@@ -9,7 +9,6 @@ import scala.scalajs.js.|
 
 /**
   * dns package object
-  * @author lawrence.daniels@gmail.com
   */
 package object dns {
 

--- a/app/common/src/main/scala/io/scalajs/nodejs/events/EventEmitter.scala
+++ b/app/common/src/main/scala/io/scalajs/nodejs/events/EventEmitter.scala
@@ -10,7 +10,6 @@ import scala.scalajs.js.annotation.JSImport
   *
   * The EventEmitter class is defined and exposed by the events module
   * @see https://nodejs.org/api/events.html
-  * @author lawrence.daniels@gmail.com
   */
 @js.native
 @JSImport("events", "EventEmitter")
@@ -18,7 +17,6 @@ class EventEmitter extends IEventEmitter
 
 /**
   * EventEmitter Interface
-  * @author lawrence.daniels@gmail.com
   */
 @js.native
 trait IEventEmitter extends js.Object {
@@ -137,7 +135,6 @@ trait IEventEmitter extends js.Object {
 
 /**
   * EventEmitter Singleton
-  * @author lawrence.daniels@gmail.com
   */
 @js.native
 @JSImport("events", JSImport.Namespace)

--- a/app/common/src/main/scala/io/scalajs/nodejs/fs/FSConstants.scala
+++ b/app/common/src/main/scala/io/scalajs/nodejs/fs/FSConstants.scala
@@ -5,7 +5,6 @@ import scala.scalajs.js
 
 /**
   * An object containing commonly used constants for file system operations
-  * @author lawrence.daniels@gmail.com
   */
 @js.native
 trait FSConstants extends js.Object {

--- a/app/common/src/main/scala/io/scalajs/nodejs/fs/FSWatcher.scala
+++ b/app/common/src/main/scala/io/scalajs/nodejs/fs/FSWatcher.scala
@@ -7,7 +7,6 @@ import scala.scalajs.js
 
 /**
   * fs.FSWatcher - Objects returned from fs.watch() are of this type.
-  * @author lawrence.daniels@gmail.com
   */
 @js.native
 trait FSWatcher extends IEventEmitter {
@@ -23,13 +22,11 @@ trait FSWatcher extends IEventEmitter {
 
 /**
   * File System Watcher Companion
-  * @author lawrence.daniels@gmail.com
   */
 object FSWatcher {
 
   /**
     * File System Watcher Extensions
-    * @author lawrence.daniels@gmail.com
     */
   implicit class FSWatcherExtensions(val watcher: FSWatcher) extends AnyVal {
 
@@ -67,7 +64,6 @@ object FSWatcher {
   * @param persistent Indicates whether the process should continue to run as long as files are being watched (default: true)
   * @param recursive  Indicates whether all subdirectories should be watched, or only the current directory.
   *                   The applies when a directory is specified, and only on supported platforms (See Caveats) (default: false)
-  * @author lawrence.daniels@gmail.com
   */
 class FSWatcherOptions(val encoding: js.UndefOr[String] = js.undefined,
                        val persistent: js.UndefOr[Boolean] = js.undefined,

--- a/app/common/src/main/scala/io/scalajs/nodejs/fs/ReadStream.scala
+++ b/app/common/src/main/scala/io/scalajs/nodejs/fs/ReadStream.scala
@@ -46,13 +46,11 @@ trait ReadStream extends Readable {
 
 /**
   * Read Stream Companion
-  * @author lawrence.daniels@gmail.com
   */
 object ReadStream {
 
   /**
     * Read Stream Events
-    * @author lawrence.daniels@gmail.com
     */
   implicit class ReadStreamEvents(val stream: ReadStream) extends AnyVal {
 
@@ -79,7 +77,6 @@ object ReadStream {
 
   /**
     * Read Stream Extensions
-    * @author lawrence.daniels@gmail.com
     */
   implicit class ReadStreamExtensions(val stream: ReadStream) extends AnyVal {
 

--- a/app/common/src/main/scala/io/scalajs/nodejs/fs/WriteStream.scala
+++ b/app/common/src/main/scala/io/scalajs/nodejs/fs/WriteStream.scala
@@ -46,13 +46,11 @@ trait WriteStream extends Writable {
 
 /**
   * Write Stream Companion
-  * @author lawrence.daniels@gmail.com
   */
 object WriteStream {
 
   /**
     * Write Stream Events
-    * @author lawrence.daniels@gmail.com
     */
   implicit class WriteStreamEvents(val stream: WriteStream) extends AnyVal {
 
@@ -79,7 +77,6 @@ object WriteStream {
 
   /**
     * Write Stream Extensions
-    * @author lawrence.daniels@gmail.com
     */
   implicit class WriteStreamExtensions(val stream: WriteStream) extends AnyVal {
 

--- a/app/common/src/main/scala/io/scalajs/nodejs/http/Agent.scala
+++ b/app/common/src/main/scala/io/scalajs/nodejs/http/Agent.scala
@@ -14,7 +14,6 @@ import scala.scalajs.js.|
   * HTTP requests are waiting on a socket to become free the socket is closed. This means
   * that Node.js's pool has the benefit of keep-alive when under load but still does not
   * require developers to manually close the HTTP clients using KeepAlive.
-  * @author lawrence.daniels@gmail.com
   */
 @js.native
 trait Agent extends js.Object {
@@ -92,13 +91,11 @@ trait Agent extends js.Object {
 
 /**
   * Agent Companion
-  * @author lawrence.daniels@gmail.com
   */
 object Agent {
 
   /**
     * Agent Extensions
-    * @author lawrence.daniels@gmail.com
     */
   implicit class AgentExtensions(val agent: Agent) extends AnyVal {
 

--- a/app/common/src/main/scala/io/scalajs/nodejs/http/Client.scala
+++ b/app/common/src/main/scala/io/scalajs/nodejs/http/Client.scala
@@ -4,7 +4,6 @@ import scala.scalajs.js
 
 /**
   * NodeJS HTTP Client
-  * @author lawrence.daniels@gmail.com
   */
 @js.native
 trait Client extends js.Object {

--- a/app/common/src/main/scala/io/scalajs/nodejs/http/ClientRequest.scala
+++ b/app/common/src/main/scala/io/scalajs/nodejs/http/ClientRequest.scala
@@ -28,7 +28,6 @@ import scala.scalajs.js.annotation.JSImport
   * lead to a 'process out of memory' error.
   *
   * Note: Node.js does not check whether Content-Length and the length of the body which has been transmitted are equal or not.
-  * @author lawrence.daniels@gmail.com
   */
 @js.native
 @JSImport("http", "ClientRequest")
@@ -185,13 +184,11 @@ class ClientRequest extends Readable {
 
 /**
   * Client Request Companion
-  * @author lawrence.daniels@gmail.com
   */
 object ClientRequest {
 
   /**
     * Client Request Events
-    * @author lawrence.daniels@gmail.com
     */
   implicit class ClientRequestEvents(val client: ClientRequest) extends AnyVal {
 
@@ -253,7 +250,6 @@ object ClientRequest {
 
   /**
     * Client Request Extensions
-    * @author lawrence.daniels@gmail.com
     */
   implicit class ClientRequestEnrichment(val client: ClientRequest) extends AnyVal {
 

--- a/app/common/src/main/scala/io/scalajs/nodejs/http/ConnectionOptions.scala
+++ b/app/common/src/main/scala/io/scalajs/nodejs/http/ConnectionOptions.scala
@@ -10,7 +10,6 @@ import scala.scalajs.js
   * @param maxSockets     Maximum number of sockets to allow per host. Default = Infinity.
   * @param maxFreeSockets Maximum number of sockets to leave open in a free state. Only relevant if keepAlive is set to
   *                       true (default: 256).
-  * @author lawrence.daniels@gmail.com
   */
 class ConnectionOptions(var keepAlive: js.UndefOr[Boolean] = js.undefined,
                         var keepAliveMsecs: js.UndefOr[Int] = js.undefined,

--- a/app/common/src/main/scala/io/scalajs/nodejs/http/Http.scala
+++ b/app/common/src/main/scala/io/scalajs/nodejs/http/Http.scala
@@ -12,7 +12,6 @@ import scala.scalajs.js.annotation.JSImport
   * traditionally difficult to use. In particular, large, possibly chunk-encoded, messages. The interface
   * is careful to never buffer entire requests or responses--the user is able to stream data.
   * @see https://nodejs.org/api/http.html
-  * @author lawrence.daniels@gmail.com
   */
 @js.native
 trait Http extends IEventEmitter {
@@ -128,7 +127,6 @@ trait Http extends IEventEmitter {
 
 /**
   * Http Singleton
-  * @author lawrence.daniels@gmail.com
   */
 @js.native
 @JSImport("http", JSImport.Namespace)

--- a/app/common/src/main/scala/io/scalajs/nodejs/http/IncomingMessage.scala
+++ b/app/common/src/main/scala/io/scalajs/nodejs/http/IncomingMessage.scala
@@ -10,7 +10,6 @@ import scala.scalajs.js
   * An IncomingMessage object is created by http.Server or http.ClientRequest and passed as the first argument
   * to the 'request' and 'response' event respectively. It may be used to access response status, headers and data.
   * It implements the Readable Stream interface, as well as the following additional events, methods, and properties.
-  * @author lawrence.daniels@gmail.com
   * @see [[https://nodejs.org/api/http.html#http_class_http_incomingmessage]]
   */
 @js.native
@@ -98,13 +97,11 @@ trait IncomingMessage extends Readable {
 
 /**
   * Incoming Message Companion
-  * @author lawrence.daniels@gmail.com
   */
 object IncomingMessage {
 
   /**
     * Incoming Message Extensions
-    * @author lawrence.daniels@gmail.com
     */
   implicit class IncomingMessageExtensions(val message: IncomingMessage) extends AnyVal {
 

--- a/app/common/src/main/scala/io/scalajs/nodejs/http/OutgoingMessage.scala
+++ b/app/common/src/main/scala/io/scalajs/nodejs/http/OutgoingMessage.scala
@@ -6,7 +6,6 @@ import scala.scalajs.js
 
 /**
   * Outgoing Message
-  * @author lawrence.daniels@gmail.com
   */
 @js.native
 trait OutgoingMessage extends stream.Writable

--- a/app/common/src/main/scala/io/scalajs/nodejs/http/RequestOptions.scala
+++ b/app/common/src/main/scala/io/scalajs/nodejs/http/RequestOptions.scala
@@ -23,7 +23,6 @@ import scala.scalajs.js
   * @param createConnection A function that produces a socket/stream to use for the request when the agent option is not used.
   *                         This can be used to avoid creating a custom Agent class just to override the default createConnection function.
   * @see [[Agent.createConnection() ]]
-  * @author lawrence.daniels@gmail.com
   */
 class RequestOptions(var protocol: js.UndefOr[String] = js.undefined,
                      var host: js.UndefOr[String] = js.undefined,

--- a/app/common/src/main/scala/io/scalajs/nodejs/http/Server.scala
+++ b/app/common/src/main/scala/io/scalajs/nodejs/http/Server.scala
@@ -10,7 +10,6 @@ import scala.scalajs.js.annotation.JSImport
 
 /**
   * http.Server - This class inherits from net.Server and has the following additional events
-  * @author lawrence.daniels@gmail.com
   */
 @js.native
 @JSImport("http", "Server")
@@ -18,7 +17,6 @@ class Server extends net.Server
 
 /**
   * Server Companion
-  * @author lawrence.daniels@gmail.com
   */
 object Server {
 

--- a/app/common/src/main/scala/io/scalajs/nodejs/http/ServerResponse.scala
+++ b/app/common/src/main/scala/io/scalajs/nodejs/http/ServerResponse.scala
@@ -10,7 +10,6 @@ import scala.scalajs.js
 /**
   * Node.js http.ServerResponse
   * @see [[https://nodejs.org/api/http.html#http_class_http_serverresponse]]
-  * @author lawrence.daniels@gmail.com
   */
 @js.native
 trait ServerResponse extends IEventEmitter with IDuplex {
@@ -135,13 +134,11 @@ trait ServerResponse extends IEventEmitter with IDuplex {
 
 /**
   * Server Response
-  * @author lawrence.daniels@gmail.com
   */
 object ServerResponse {
 
   /**
     * Server Response Events
-    * @author lawrence.daniels@gmail.com
     */
   implicit class ServerResponseEvents(val response: ServerResponse) extends AnyVal {
 
@@ -155,7 +152,6 @@ object ServerResponse {
 
   /**
     * Server Response Extensions
-    * @author lawrence.daniels@gmail.com
     */
   implicit class ServerResponseExtensions(val response: ServerResponse) extends AnyVal {
 

--- a/app/common/src/main/scala/io/scalajs/nodejs/http/package.scala
+++ b/app/common/src/main/scala/io/scalajs/nodejs/http/package.scala
@@ -8,13 +8,11 @@ import scala.scalajs.js
 
 /**
   * http package object
-  * @author lawrence.daniels@gmail.com
   */
 package object http {
 
   /**
     * Http Extensions
-    * @author lawrence.daniels@gmail.com
     */
   implicit class HttpExtensions(val http: Http) extends AnyVal {
 
@@ -64,7 +62,6 @@ package object http {
 
   /**
     * Server Events
-    * @author lawrence.daniels@gmail.com
     */
   implicit class ServerEvents(val server: Server) extends AnyVal {
 

--- a/app/common/src/main/scala/io/scalajs/nodejs/https/Agent.scala
+++ b/app/common/src/main/scala/io/scalajs/nodejs/https/Agent.scala
@@ -6,7 +6,6 @@ import scala.scalajs.js
 
 /**
   * HTTPS is the HTTP protocol over TLS/SSL. In Node.js this is implemented as a separate module.
-  * @author lawrence.daniels@gmail.com
   */
 @js.native
 trait Agent extends nodejs.http.Agent

--- a/app/common/src/main/scala/io/scalajs/nodejs/https/Https.scala
+++ b/app/common/src/main/scala/io/scalajs/nodejs/https/Https.scala
@@ -11,7 +11,6 @@ import scala.scalajs.js.|
 /**
   * HTTPS is the HTTP protocol over TLS/SSL. In Node.js this is implemented as a separate module.
   * @see https://nodejs.org/api/https.html
-  * @author lawrence.daniels@gmail.com
   */
 @js.native
 trait Https extends IEventEmitter {
@@ -75,7 +74,6 @@ trait Https extends IEventEmitter {
 
 /**
   * Https Singleton
-  * @author lawrence.daniels@gmail.com
   */
 @js.native
 @JSImport("https", JSImport.Namespace)

--- a/app/common/src/main/scala/io/scalajs/nodejs/https/Server.scala
+++ b/app/common/src/main/scala/io/scalajs/nodejs/https/Server.scala
@@ -6,7 +6,6 @@ import scala.scalajs.js.annotation.JSImport
 
 /**
   * This class is a subclass of tls.Server and emits events same as http.Server. See http.Server for more information.
-  * @author lawrence.daniels@gmail.com
   */
 @js.native
 @JSImport("https", "Server")

--- a/app/common/src/main/scala/io/scalajs/nodejs/https/ServerOptions.scala
+++ b/app/common/src/main/scala/io/scalajs/nodejs/https/ServerOptions.scala
@@ -24,7 +24,6 @@ import scala.scalajs.js
   *                     <li>Agent object: explicitly use the passed in Agent.</li>
   *                     <li>false: opts out of connection pooling with an Agent, defaults request to Connection: close.</li>
   *                     </ul>
-  * @author lawrence.daniels@gmail.com
   */
 class ServerOptions(var host: js.UndefOr[String] = js.undefined,
                     var hostname: js.UndefOr[String] = js.undefined,

--- a/app/common/src/main/scala/io/scalajs/nodejs/https/package.scala
+++ b/app/common/src/main/scala/io/scalajs/nodejs/https/package.scala
@@ -9,13 +9,11 @@ import scala.scalajs.js.|
 
 /**
   * https package object
-  * @author lawrence.daniels@gmail.com
   */
 package object https {
 
   /**
     * Https Extensions
-    * @author lawrence.daniels@gmail.com
     */
   final implicit class HttpExtensions(val https: Https) extends AnyVal {
 

--- a/app/common/src/main/scala/io/scalajs/nodejs/net/Address.scala
+++ b/app/common/src/main/scala/io/scalajs/nodejs/net/Address.scala
@@ -4,7 +4,6 @@ import scala.scalajs.js
 
 /**
   * Server IP Address
-  * @author lawrence.daniels@gmail.com
   */
 @js.native
 trait Address extends js.Object {

--- a/app/common/src/main/scala/io/scalajs/nodejs/net/ConnectOptions.scala
+++ b/app/common/src/main/scala/io/scalajs/nodejs/net/ConnectOptions.scala
@@ -4,6 +4,5 @@ import scala.scalajs.js
 
 /**
   * Connect Options
-  * @author lawrence.daniels@gmail.com
   */
 class ConnectOptions(path: String = null, host: String = null, port: Integer = null) extends js.Object

--- a/app/common/src/main/scala/io/scalajs/nodejs/net/ListenerOptions.scala
+++ b/app/common/src/main/scala/io/scalajs/nodejs/net/ListenerOptions.scala
@@ -4,7 +4,6 @@ import scala.scalajs.js
 
 /**
   * Listener Options
-  * @author lawrence.daniels@gmail.com
   */
 class ListenerOptions(var host: js.UndefOr[String] = js.undefined,
                       var port: js.UndefOr[Int] = js.undefined,

--- a/app/common/src/main/scala/io/scalajs/nodejs/net/Net.scala
+++ b/app/common/src/main/scala/io/scalajs/nodejs/net/Net.scala
@@ -9,7 +9,6 @@ import scala.scalajs.js.annotation.JSImport
   * net - The net module provides you with an asynchronous network wrapper. It contains functions for creating both
   * servers and clients (called streams).
   * @see https://nodejs.org/api/net.html
-  * @author lawrence.daniels@gmail.com
   */
 @js.native
 trait Net extends IEventEmitter {
@@ -156,7 +155,6 @@ trait Net extends IEventEmitter {
 
 /**
   * Net Singleton
-  * @author lawrence.daniels@gmail.com
   */
 @js.native
 @JSImport("net", JSImport.Namespace)

--- a/app/common/src/main/scala/io/scalajs/nodejs/net/Server.scala
+++ b/app/common/src/main/scala/io/scalajs/nodejs/net/Server.scala
@@ -9,7 +9,6 @@ import scala.scalajs.js.annotation.JSImport
 /**
   * net.Server - This class is used to create a TCP or local server.
   * @see https://nodejs.org/api/net.html#net_class_net_server
-  * @author lawrence.daniels@gmail.com
   */
 @js.native
 @JSImport("net", "Server")
@@ -154,7 +153,6 @@ class Server() extends IEventEmitter {
 
 /**
   * Server Companion
-  * @author lawrence.daniels@gmail.com
   */
 object Server extends {
 
@@ -198,7 +196,6 @@ object Server extends {
 
 /**
   * Server Options
-  * @author lawrence.daniels@gmail.com
   */
 class ServerOptions(val allowHalfOpen: js.UndefOr[Boolean] = js.undefined,
                     val pauseOnConnect: js.UndefOr[Boolean] = js.undefined)

--- a/app/common/src/main/scala/io/scalajs/nodejs/net/Socket.scala
+++ b/app/common/src/main/scala/io/scalajs/nodejs/net/Socket.scala
@@ -12,7 +12,6 @@ import scala.scalajs.js.|
   * net.Socket - This object is an abstraction of a TCP or local socket. net.Socket instances implement a duplex Stream
   * interface. They can be created by the user and used as a client (with connect()) or they can be created by Node.js
   * and passed to the user through the 'connection' event of a server.
-  * @author lawrence.daniels@gmail.com
   */
 @js.native
 @JSImport("net", "Socket")
@@ -223,7 +222,6 @@ class Socket(options: SocketOptions | RawOptions = js.native) extends IDuplex {
 
 /**
   * Socket Singleton
-  * @author lawrence.daniels@gmail.com
   */
 object Socket extends {}
 
@@ -235,7 +233,6 @@ object Socket extends {}
   * @param allowHalfOpen
   * @param readable
   * @param writable
-  * @author lawrence.daniels@gmail.com
   */
 class SocketOptions(val fd: js.UndefOr[FileDescriptor] = js.undefined,
                     val allowHalfOpen: js.UndefOr[Boolean] = js.undefined,

--- a/app/common/src/main/scala/io/scalajs/nodejs/os/CPUInfo.scala
+++ b/app/common/src/main/scala/io/scalajs/nodejs/os/CPUInfo.scala
@@ -4,7 +4,6 @@ import scala.scalajs.js
 
 /**
   * CPU Information
-  * @author lawrence.daniels@gmail.com
   */
 @js.native
 trait CPUInfo extends js.Object {

--- a/app/common/src/main/scala/io/scalajs/nodejs/os/CPUTime.scala
+++ b/app/common/src/main/scala/io/scalajs/nodejs/os/CPUTime.scala
@@ -4,7 +4,6 @@ import scala.scalajs.js
 
 /**
   * CPU Time
-  * @author lawrence.daniels@gmail.com
   */
 @js.native
 trait CPUTime extends js.Object {

--- a/app/common/src/main/scala/io/scalajs/nodejs/os/NetworkInterface.scala
+++ b/app/common/src/main/scala/io/scalajs/nodejs/os/NetworkInterface.scala
@@ -4,7 +4,6 @@ import scala.scalajs.js
 
 /**
   * Represents a Network Interface
-  * @author lawrence.daniels@gmail.com
   */
 class NetworkInterface(val address: String,
                        val netmask: String,

--- a/app/common/src/main/scala/io/scalajs/nodejs/os/OS.scala
+++ b/app/common/src/main/scala/io/scalajs/nodejs/os/OS.scala
@@ -6,7 +6,6 @@ import scala.scalajs.js.annotation.JSImport
 /**
   * Provides a few basic operating-system related utility functions.
   * @see https://nodejs.org/api/os.html
-  * @author lawrence.daniels@gmail.com
   */
 @js.native
 trait OS extends js.Object {
@@ -148,7 +147,6 @@ trait OS extends js.Object {
 
 /**
   * Operating System Singleton
-  * @author lawrence.daniels@gmail.com
   */
 @js.native
 @JSImport("os", JSImport.Namespace)

--- a/app/common/src/main/scala/io/scalajs/nodejs/os/UserInfoOptions.scala
+++ b/app/common/src/main/scala/io/scalajs/nodejs/os/UserInfoOptions.scala
@@ -4,7 +4,6 @@ import scala.scalajs.js
 
 /**
   * User Info Options
-  * @author lawrence.daniels@gmail.com
   */
 class UserInfoOptions(var encoding: js.UndefOr[String] = js.undefined,
                       var username: js.UndefOr[String] = js.undefined,

--- a/app/common/src/main/scala/io/scalajs/nodejs/os/package.scala
+++ b/app/common/src/main/scala/io/scalajs/nodejs/os/package.scala
@@ -4,7 +4,6 @@ import scala.scalajs.js
 
 /**
   * os package object
-  * @author lawrence.daniels@gmail.com
   */
 package object os {
 

--- a/app/common/src/main/scala/io/scalajs/nodejs/package.scala
+++ b/app/common/src/main/scala/io/scalajs/nodejs/package.scala
@@ -9,7 +9,6 @@ import scala.scalajs.js.|
 
 /**
   * nodejs package object
-  * @author lawrence.daniels@gmail.com
   */
 package object nodejs {
 

--- a/app/common/src/main/scala/io/scalajs/nodejs/path/Path.scala
+++ b/app/common/src/main/scala/io/scalajs/nodejs/path/Path.scala
@@ -7,7 +7,6 @@ import scala.scalajs.js.annotation.JSImport
   * This module contains utilities for handling and transforming file paths. The file system is not consulted to
   * check whether paths are valid.
   * @see https://nodejs.org/docs/latest/api/path.html
-  * @author lawrence.daniels@gmail.com
   */
 @js.native
 trait Path extends js.Object {
@@ -138,7 +137,6 @@ trait Path extends js.Object {
 
 /**
   * Path Singleton
-  * @author lawrence.daniels@gmail.com
   */
 @js.native
 @JSImport("path", JSImport.Namespace)

--- a/app/common/src/main/scala/io/scalajs/nodejs/path/PathObject.scala
+++ b/app/common/src/main/scala/io/scalajs/nodejs/path/PathObject.scala
@@ -4,7 +4,6 @@ import scala.scalajs.js
 
 /**
   * Path Object
-  * @author lawrence.daniels@gmail.com
   */
 class PathObject(val root: js.UndefOr[String] = js.undefined,
                  val dir: js.UndefOr[String] = js.undefined,

--- a/app/common/src/main/scala/io/scalajs/nodejs/querystring/QueryDecodeOptions.scala
+++ b/app/common/src/main/scala/io/scalajs/nodejs/querystring/QueryDecodeOptions.scala
@@ -9,7 +9,6 @@ import scala.scalajs.js
   * @param maxKeys            Specifies the maximum number of keys to parse. Defaults to 1000. Specify 0 to remove
   *                           key counting limitations. The querystring.parse() method parses a URL query string (str)
   *                           into a collection of key and value pairs.
-  * @author lawrence.daniels@gmail.com
   */
 class QueryDecodeOptions(val decodeURIComponent: js.UndefOr[js.Function] = js.undefined,
                          val maxKeys: js.UndefOr[Int] = js.undefined)

--- a/app/common/src/main/scala/io/scalajs/nodejs/querystring/QueryEncodeOptions.scala
+++ b/app/common/src/main/scala/io/scalajs/nodejs/querystring/QueryEncodeOptions.scala
@@ -6,6 +6,5 @@ import scala.scalajs.js
   * Query String Encode Options
   * @param encodeURIComponent The function to use when converting URL-unsafe characters to percent-encoding in
   *                           the query string. Defaults to querystring.escape().
-  * @author lawrence.daniels@gmail.com
   */
 class QueryEncodeOptions(val encodeURIComponent: js.UndefOr[js.Function] = js.undefined) extends js.Object

--- a/app/common/src/main/scala/io/scalajs/nodejs/querystring/QueryString.scala
+++ b/app/common/src/main/scala/io/scalajs/nodejs/querystring/QueryString.scala
@@ -9,7 +9,6 @@ import scala.scalajs.js.|
 /**
   * Query String
   * @see https://nodejs.org/api/querystring.html
-  * @author lawrence.daniels@gmail.com
   */
 @js.native
 @JSImport("querystring", JSImport.Namespace)
@@ -17,7 +16,6 @@ object QueryString extends QueryString
 
 /**
   * Query String Type Definition
-  * @author lawrence.daniels@gmail.com
   */
 @js.native
 trait QueryString extends js.Object {

--- a/app/common/src/main/scala/io/scalajs/nodejs/querystring/package.scala
+++ b/app/common/src/main/scala/io/scalajs/nodejs/querystring/package.scala
@@ -6,7 +6,6 @@ import scala.scalajs.js.|
 
 /**
   * query string package object
-  * @author lawrence.daniels@gmail.com
   */
 package object querystring {
 

--- a/app/common/src/main/scala/io/scalajs/nodejs/readline/Interface.scala
+++ b/app/common/src/main/scala/io/scalajs/nodejs/readline/Interface.scala
@@ -7,7 +7,6 @@ import scala.scalajs.js
 /**
   * Readline Interface
   * @see https://nodejs.org/api/readline.html#readline_class_interface
-  * @author lawrence.daniels@gmail.com
   */
 @js.native
 trait Interface extends IEventEmitter {
@@ -86,7 +85,6 @@ trait Interface extends IEventEmitter {
 
 /**
   * Readline Interface Companion
-  * @author lawrence.daniels@gmail.com
   */
 object Interface {
 

--- a/app/common/src/main/scala/io/scalajs/nodejs/readline/Readline.scala
+++ b/app/common/src/main/scala/io/scalajs/nodejs/readline/Readline.scala
@@ -12,7 +12,6 @@ import scala.scalajs.js.|
   * To use this module, do require('readline').
   * Note that once you've invoked this module, your Node.js program will not terminate until you've closed the interface.
   * @see https://nodejs.org/api/readline.html
-  * @author lawrence.daniels@gmail.com
   */
 @js.native
 trait Readline extends IEventEmitter {
@@ -56,7 +55,6 @@ trait Readline extends IEventEmitter {
 
 /**
   * Readline Singleton
-  * @author lawrence.daniels@gmail.com
   */
 @js.native
 @JSImport("readline", JSImport.Namespace)

--- a/app/common/src/main/scala/io/scalajs/nodejs/readline/ReadlineOptions.scala
+++ b/app/common/src/main/scala/io/scalajs/nodejs/readline/ReadlineOptions.scala
@@ -6,7 +6,6 @@ import scala.scalajs.js
 
 /**
   * Readline Options
-  * @author lawrence.daniels@gmail.com
   */
 class ReadlineOptions(var input: js.UndefOr[Readable] = js.undefined,
                       var output: js.UndefOr[Writable] = js.undefined,

--- a/app/common/src/main/scala/io/scalajs/nodejs/repl/REPL.scala
+++ b/app/common/src/main/scala/io/scalajs/nodejs/repl/REPL.scala
@@ -12,7 +12,6 @@ import scala.scalajs.js.|
   * The repl module provides a Read-Eval-Print-Loop (REPL) implementation that is available
   * both as a standalone program or includable in other applications.
   * @see https://nodejs.org/api/repl.html#repl_repl
-  * @author lawrence.daniels@gmail.com
   */
 @js.native
 trait REPL extends IEventEmitter {
@@ -44,7 +43,6 @@ trait REPL extends IEventEmitter {
 
 /**
   * REPL Singleton
-  * @author lawrence.daniels@gmail.com
   */
 @js.native
 @JSImport("repl", JSImport.Namespace)

--- a/app/common/src/main/scala/io/scalajs/nodejs/repl/REPLOptions.scala
+++ b/app/common/src/main/scala/io/scalajs/nodejs/repl/REPLOptions.scala
@@ -30,7 +30,6 @@ import scala.scalajs.js
   *                        <li>repl.REPL_MODE_MAGIC - attempt to run commands in default mode. If they fail to parse,
   *                        re-try in strict mode.</li>
   *                        </ul>
-  * @author lawrence.daniels@gmail.com
   */
 class REPLOptions(var prompt: js.UndefOr[String] = js.undefined,
                   var input: js.UndefOr[Readable] = js.undefined,

--- a/app/common/src/main/scala/io/scalajs/nodejs/repl/REPLServer.scala
+++ b/app/common/src/main/scala/io/scalajs/nodejs/repl/REPLServer.scala
@@ -7,7 +7,6 @@ import scala.scalajs.js
 
 /**
   * REPL Server
-  * @author lawrence.daniels@gmail.com
   */
 @js.native
 trait REPLServer extends IEventEmitter with Interface {
@@ -57,7 +56,6 @@ trait REPLServer extends IEventEmitter with Interface {
 
 /**
   * REPL Server Companion
-  * @author lawrence.daniels@gmail.com
   */
 object REPLServer {
 

--- a/app/common/src/main/scala/io/scalajs/nodejs/repl/package.scala
+++ b/app/common/src/main/scala/io/scalajs/nodejs/repl/package.scala
@@ -4,7 +4,6 @@ import scala.scalajs.js
 
 /**
   * repl package object
-  * @author lawrence.daniels@gmail.com
   */
 package object repl {
 

--- a/app/common/src/main/scala/io/scalajs/nodejs/stream/Duplex.scala
+++ b/app/common/src/main/scala/io/scalajs/nodejs/stream/Duplex.scala
@@ -14,7 +14,6 @@ import scala.scalajs.js.annotation.JSImport
   * from Readable, and then parasitically from Writable. It is thus up to the user to implement both
   * the low-level stream._read(n) method as well as the low-level stream._write(chunk, encoding, callback)
   * method on extension duplex classes.
-  * @author lawrence.daniels@gmail.com
   */
 @js.native
 @JSImport("stream", "Duplex")

--- a/app/common/src/main/scala/io/scalajs/nodejs/stream/PassThrough.scala
+++ b/app/common/src/main/scala/io/scalajs/nodejs/stream/PassThrough.scala
@@ -6,7 +6,6 @@ import scala.scalajs.js
   * This is a trivial implementation of a Transform stream that simply passes the input bytes across to the output.
   * Its purpose is mainly for examples and testing, but there are occasionally use cases where it can come in handy
   * as a building block for novel sorts of streams.
-  * @author lawrence.daniels@gmail.com
   */
 @js.native
 trait PassThrough extends Transform

--- a/app/common/src/main/scala/io/scalajs/nodejs/stream/Readable.scala
+++ b/app/common/src/main/scala/io/scalajs/nodejs/stream/Readable.scala
@@ -13,7 +13,6 @@ import scala.scalajs.js.|
   * The Readable stream interface is the abstraction for a source of data that you are reading from.
   * In other words, data comes out of a Readable stream.
   * @see https://nodejs.org/api/stream.html#stream_readable_streams
-  * @author lawrence.daniels@gmail.com
   */
 @js.native
 trait Readable extends IEventEmitter {
@@ -180,13 +179,11 @@ trait Readable extends IEventEmitter {
 
 /**
   * Readable Companion
-  * @author lawrence.daniels@gmail.com
   */
 object Readable {
 
   /**
     * Readable Events
-    * @author lawrence.daniels@gmail.com
     */
   implicit class ReadableEvents(val readable: Readable) extends AnyVal {
 
@@ -262,7 +259,6 @@ class ReadablePipeOptions(val end: js.UndefOr[Boolean] = js.undefined) extends j
 
 /**
   * Readable State
-  * @author lawrence.daniels@gmail.com
   */
 @js.native
 trait ReadableState extends js.Object {

--- a/app/common/src/main/scala/io/scalajs/nodejs/stream/Transform.scala
+++ b/app/common/src/main/scala/io/scalajs/nodejs/stream/Transform.scala
@@ -6,7 +6,6 @@ import scala.scalajs.js.annotation.JSImport
 /**
   * Transform streams are Duplex streams where the output is in some way computed from the input.
   * They implement both the Readable and Writable interfaces.
-  * @author lawrence.daniels@gmail.com
   */
 @js.native
 @JSImport("stream", "Transform")

--- a/app/common/src/main/scala/io/scalajs/nodejs/stream/Writable.scala
+++ b/app/common/src/main/scala/io/scalajs/nodejs/stream/Writable.scala
@@ -12,7 +12,6 @@ import scala.scalajs.js.|
 
 /**
   * The Writable stream interface is an abstraction for a destination that you are writing data to.
-  * @author lawrence.daniels@gmail.com
   */
 @js.native
 trait Writable extends IEventEmitter {
@@ -150,13 +149,11 @@ trait Writable extends IEventEmitter {
 
 /**
   * Writable Companion
-  * @author lawrence.daniels@gmail.com
   */
 object Writable {
 
   /**
     * Writable Events
-    * @author lawrence.daniels@gmail.com
     */
   implicit class WritableEvents[T <: Writable](val writable: T) extends AnyVal {
 
@@ -205,7 +202,6 @@ object Writable {
 
   /**
     * Writable Extensions
-    * @author lawrence.daniels@gmail.com
     */
   implicit class WritableExtensions[T <: Writable](val writable: T) extends AnyVal {
 

--- a/app/common/src/main/scala/io/scalajs/nodejs/timers/Immediate.scala
+++ b/app/common/src/main/scala/io/scalajs/nodejs/timers/Immediate.scala
@@ -6,7 +6,6 @@ import scala.scalajs.js
 
 /**
   * Immediate Handle
-  * @author lawrence.daniels@gmail.com
   */
 @js.native
 trait Immediate extends js.Object {
@@ -17,7 +16,6 @@ trait Immediate extends js.Object {
 
 /**
   * Immediate Companion
-  * @author lawrence.daniels@gmail.com
   */
 object Immediate {
 

--- a/app/common/src/main/scala/io/scalajs/nodejs/timers/Interval.scala
+++ b/app/common/src/main/scala/io/scalajs/nodejs/timers/Interval.scala
@@ -6,7 +6,6 @@ import scala.scalajs.js
 
 /**
   * Interval Handle
-  * @author lawrence.daniels@gmail.com
   */
 @js.native
 trait Interval extends js.Object {
@@ -21,7 +20,6 @@ trait Interval extends js.Object {
 
 /**
   * Interval Companion
-  * @author lawrence.daniels@gmail.com
   */
 object Interval {
 

--- a/app/common/src/main/scala/io/scalajs/nodejs/timers/Ref.scala
+++ b/app/common/src/main/scala/io/scalajs/nodejs/timers/Ref.scala
@@ -5,7 +5,6 @@ import scala.scalajs.js
 /**
   * If a timer was previously unref()d, then ref() can be called to explicitly request the timer hold the
   * program open. If the timer is already refd calling ref again will have no effect.
-  * @author lawrence.daniels@gmail.com
   */
 @js.native
 trait Ref extends js.Object {

--- a/app/common/src/main/scala/io/scalajs/nodejs/timers/SetImmediate.scala
+++ b/app/common/src/main/scala/io/scalajs/nodejs/timers/SetImmediate.scala
@@ -6,7 +6,6 @@ import scala.scalajs.js
   * Schedules "immediate" execution of callback after I/O events' callbacks and before timers set
   * by setTimeout and setInterval are triggered. Returns an immediateObject for possible use with
   * clearImmediate. Additional optional arguments may be passed to the callback.
-  * @author lawrence.daniels@gmail.com
   */
 @js.native
 trait SetImmediate extends js.Object {

--- a/app/common/src/main/scala/io/scalajs/nodejs/timers/SetInterval.scala
+++ b/app/common/src/main/scala/io/scalajs/nodejs/timers/SetInterval.scala
@@ -5,7 +5,6 @@ import scala.scalajs.js
 /**
   * Schedules repeated execution of callback every delay milliseconds. Returns a intervalObject for possible
   * use with clearInterval. Additional optional arguments may be passed to the callback.
-  * @author lawrence.daniels@gmail.com
   */
 @js.native
 trait SetInterval extends js.Object {

--- a/app/common/src/main/scala/io/scalajs/nodejs/timers/SetTimeout.scala
+++ b/app/common/src/main/scala/io/scalajs/nodejs/timers/SetTimeout.scala
@@ -5,7 +5,6 @@ import scala.scalajs.js
 /**
   * Schedules execution of a one-time callback after delay milliseconds. Returns a timeoutObject for possible
   * use with clearTimeout. Additional optional arguments may be passed to the callback.
-  * @author lawrence.daniels@gmail.com
   */
 @js.native
 trait SetTimeout extends js.Object {

--- a/app/common/src/main/scala/io/scalajs/nodejs/timers/Timeout.scala
+++ b/app/common/src/main/scala/io/scalajs/nodejs/timers/Timeout.scala
@@ -6,7 +6,6 @@ import scala.scalajs.js
 
 /**
   * Timeout Handle
-  * @author lawrence.daniels@gmail.com
   */
 @js.native
 trait Timeout extends js.Object {
@@ -21,7 +20,6 @@ trait Timeout extends js.Object {
 
 /**
   * Timeout Companion
-  * @author lawrence.daniels@gmail.com
   */
 object Timeout {
 

--- a/app/common/src/main/scala/io/scalajs/nodejs/timers/Timer.scala
+++ b/app/common/src/main/scala/io/scalajs/nodejs/timers/Timer.scala
@@ -4,7 +4,6 @@ import scala.scalajs.js
 
 /**
   * Timer
-  * @author lawrence.daniels@gmail.com
   */
 @js.native
 trait Timer extends js.Object

--- a/app/common/src/main/scala/io/scalajs/nodejs/timers/UnRef.scala
+++ b/app/common/src/main/scala/io/scalajs/nodejs/timers/UnRef.scala
@@ -6,7 +6,6 @@ import scala.scalajs.js
   * The opaque value returned by setTimeout and setInterval also has the method timer.unref() which allows
   * the creation of a timer that is active but if it is the only item left in the event loop, it won't keep
   * the program running. If the timer is already unrefd calling unref again will have no effect.
-  * @author lawrence.daniels@gmail.com
   */
 @js.native
 trait UnRef extends js.Object {

--- a/app/common/src/main/scala/io/scalajs/nodejs/tls/Server.scala
+++ b/app/common/src/main/scala/io/scalajs/nodejs/tls/Server.scala
@@ -9,7 +9,6 @@ import scala.scalajs.js.annotation.JSImport
 /**
   * The tls.Server class is a subclass of net.Server that accepts encrypted connections using TLS or SSL.
   * @see https://nodejs.org/dist/v7.6.0/docs/api/tls.html#tls_class_tls_server
-  * @author lawrence.daniels@gmail.com
   */
 @js.native
 @JSImport("tls", "Server")

--- a/app/common/src/main/scala/io/scalajs/nodejs/tls/Tls.scala
+++ b/app/common/src/main/scala/io/scalajs/nodejs/tls/Tls.scala
@@ -11,7 +11,6 @@ import scala.scalajs.js.|
   * The tls module provides an implementation of the Transport Layer Security (TLS) and Secure Socket Layer (SSL)
   * protocols that is built on top of OpenSSL.
   * @see https://nodejs.org/dist/v7.6.0/docs/api/tls.html
-  * @author lawrence.daniels@gmail.com
   */
 @js.native
 trait Tls extends js.Object {
@@ -30,7 +29,6 @@ trait Tls extends js.Object {
 
 /**
   * TLS Singleton
-  * @author lawrence.daniels@gmail.com
   */
 @js.native
 @JSImport("tls", JSImport.Namespace)

--- a/app/common/src/main/scala/io/scalajs/nodejs/tty/ReadStream.scala
+++ b/app/common/src/main/scala/io/scalajs/nodejs/tty/ReadStream.scala
@@ -12,7 +12,6 @@ import scala.scalajs.js.annotation.JSImport
   * In normal circumstances process.stdin will be the only tty.ReadStream instance in a Node.js process
   * and there should be no reason to create additional instances.
   * @see https://nodejs.org/api/tty.html
-  * @author lawrence.daniels@gmail.com
   */
 @js.native
 @JSImport("tty", "ReadStream")

--- a/app/common/src/main/scala/io/scalajs/nodejs/tty/TTY.scala
+++ b/app/common/src/main/scala/io/scalajs/nodejs/tty/TTY.scala
@@ -9,7 +9,6 @@ import scala.scalajs.js.annotation.JSImport
   * The tty module provides the tty.ReadStream and tty.WriteStream classes. In most cases, it will not be necessary
   * or possible to use this module directly.
   * @see https://nodejs.org/api/tty.html
-  * @author lawrence.daniels@gmail.com
   */
 @js.native
 trait TTY extends js.Object {
@@ -29,7 +28,6 @@ trait TTY extends js.Object {
 
 /**
   * TTY Singleton
-  * @author lawrence.daniels@gmail.com
   */
 @js.native
 @JSImport("tty", JSImport.Namespace)

--- a/app/common/src/main/scala/io/scalajs/nodejs/tty/package.scala
+++ b/app/common/src/main/scala/io/scalajs/nodejs/tty/package.scala
@@ -2,7 +2,6 @@ package io.scalajs.nodejs
 
 /**
   * tty package object
-  * @author lawrence.daniels@gmail.com
   */
 package object tty {
 

--- a/app/common/src/main/scala/io/scalajs/nodejs/util/InspectOptions.scala
+++ b/app/common/src/main/scala/io/scalajs/nodejs/util/InspectOptions.scala
@@ -19,7 +19,6 @@ import scala.scalajs.js
   * @param breakLength    The length at which an object's keys are split across multiple lines. Set to Infinity to
   *                       format an object as a single line. Defaults to 60 for legacy compatibility.
   * @see [[https://nodejs.org/api/util.html#util_util_inspect_object_options]]
-  * @author lawrence.daniels@gmail.com
   */
 class InspectOptions(var showHidden: js.UndefOr[Boolean] = js.undefined,
                      var depth: js.UndefOr[Int] = js.undefined,

--- a/app/common/src/main/scala/io/scalajs/nodejs/util/Util.scala
+++ b/app/common/src/main/scala/io/scalajs/nodejs/util/Util.scala
@@ -16,7 +16,6 @@ import scala.scalajs.js.|
   * We are not interested in any future additions to the util module that are unnecessary
   * for Node.js's internal functionality.
   * @see https://nodejs.org/api/util.html
-  * @author lawrence.daniels@gmail.com
   */
 @js.native
 trait Util extends IEventEmitter {
@@ -220,7 +219,6 @@ trait Util extends IEventEmitter {
 
 /**
   * Util Singleton
-  * @author lawrence.daniels@gmail.com
   */
 @js.native
 @JSImport("util", JSImport.Namespace)

--- a/app/common/src/main/scala/io/scalajs/nodejs/vm/ContextOptions.scala
+++ b/app/common/src/main/scala/io/scalajs/nodejs/vm/ContextOptions.scala
@@ -11,7 +11,6 @@ import scala.scalajs.js
   *                      is attached to the stack trace.
   * @param timeout       Specifies the number of milliseconds to execute code before terminating execution. If execution
   *                      is terminated, an Error will be thrown.
-  * @author lawrence.daniels@gmail.com
   */
 class ContextOptions(var filename: js.UndefOr[String] = js.undefined,
                      var lineOffset: js.UndefOr[Int] = js.undefined,

--- a/app/common/src/main/scala/io/scalajs/nodejs/vm/ContextifyScript.scala
+++ b/app/common/src/main/scala/io/scalajs/nodejs/vm/ContextifyScript.scala
@@ -4,7 +4,6 @@ import scala.scalajs.js
 
 /**
   * Contextify Script
-  * @author lawrence.daniels@gmail.com
   */
 @js.native
 trait ContextifyScript extends js.Object {

--- a/app/common/src/main/scala/io/scalajs/nodejs/vm/ScriptContext.scala
+++ b/app/common/src/main/scala/io/scalajs/nodejs/vm/ScriptContext.scala
@@ -4,7 +4,6 @@ import scala.scalajs.js
 
 /**
   * Script Context
-  * @author lawrence.daniels@gmail.com
   */
 @js.native
 trait ScriptContext extends js.Object

--- a/app/common/src/main/scala/io/scalajs/nodejs/vm/ScriptOptions.scala
+++ b/app/common/src/main/scala/io/scalajs/nodejs/vm/ScriptOptions.scala
@@ -19,7 +19,6 @@ import scala.scalajs.js
   *                          a Buffer with V8's code cache data will be produced and stored in the cachedData property of the returned
   *                          vm.Script instance. The cachedDataProduced value will be set to either true or false depending on whether
   *                          code cache data is produced successfully.
-  * @author lawrence.daniels@gmail.com
   */
 class ScriptOptions(var filename: js.UndefOr[String] = js.undefined,
                     var lineOffset: js.UndefOr[Int] = js.undefined,

--- a/app/common/src/main/scala/io/scalajs/nodejs/vm/VM.scala
+++ b/app/common/src/main/scala/io/scalajs/nodejs/vm/VM.scala
@@ -9,7 +9,6 @@ import scala.scalajs.js.|
 /**
   * The vm module provides APIs for compiling and running code within V8 Virtual Machine contexts.
   * @see https://nodejs.org/api/vm.html
-  * @author lawrence.daniels@gmail.com
   */
 @js.native
 trait VM extends js.Object {
@@ -94,7 +93,6 @@ trait VM extends js.Object {
 
 /**
   * Virtual Machine Singleton
-  * @author lawrence.daniels@gmail.com
   */
 @js.native
 @JSImport("vm", JSImport.Namespace)

--- a/app/common/src/main/scala/io/scalajs/nodejs/zlib/CompressionAlgorithm.scala
+++ b/app/common/src/main/scala/io/scalajs/nodejs/zlib/CompressionAlgorithm.scala
@@ -6,7 +6,6 @@ import scala.scalajs.js
 
 /**
   * Compression Algorithm
-  * @author lawrence.daniels@gmail.com
   */
 @js.native
 trait CompressionAlgorithm extends stream.Readable with stream.Writable

--- a/app/common/src/main/scala/io/scalajs/nodejs/zlib/CompressionOptions.scala
+++ b/app/common/src/main/scala/io/scalajs/nodejs/zlib/CompressionOptions.scala
@@ -12,7 +12,6 @@ import scala.scalajs.js
   * @param memLevel    (compression only)
   * @param strategy    (compression only)
   * @param windowBits  ???
-  * @author lawrence.daniels@gmail.com
   */
 class CompressionOptions(var chunkSize: js.UndefOr[Int] = js.undefined,
                          var dictionary: js.UndefOr[js.Dictionary[js.Any]] = js.undefined,

--- a/app/common/src/main/scala/io/scalajs/nodejs/zlib/Deflate.scala
+++ b/app/common/src/main/scala/io/scalajs/nodejs/zlib/Deflate.scala
@@ -5,7 +5,6 @@ import scala.scalajs.js
 
 /**
   * Compress data using deflate.
-  * @author lawrence.daniels@gmail.com
   */
 @js.native
 trait Deflate extends CompressionAlgorithm

--- a/app/common/src/main/scala/io/scalajs/nodejs/zlib/DeflateRaw.scala
+++ b/app/common/src/main/scala/io/scalajs/nodejs/zlib/DeflateRaw.scala
@@ -5,7 +5,6 @@ import scala.scalajs.js
 
 /**
   * Compress data using deflate, and do not append a zlib header.
-  * @author lawrence.daniels@gmail.com
   */
 @js.native
 trait DeflateRaw extends CompressionAlgorithm

--- a/app/common/src/main/scala/io/scalajs/nodejs/zlib/Gunzip.scala
+++ b/app/common/src/main/scala/io/scalajs/nodejs/zlib/Gunzip.scala
@@ -5,7 +5,6 @@ import scala.scalajs.js
 
 /**
   * Decompress a gzip stream.
-  * @author lawrence.daniels@gmail.com
   */
 @js.native
 trait Gunzip extends CompressionAlgorithm

--- a/app/common/src/main/scala/io/scalajs/nodejs/zlib/Gzip.scala
+++ b/app/common/src/main/scala/io/scalajs/nodejs/zlib/Gzip.scala
@@ -5,7 +5,6 @@ import scala.scalajs.js
 
 /**
   * Compress data using gzip.
-  * @author lawrence.daniels@gmail.com
   */
 @js.native
 trait Gzip extends CompressionAlgorithm

--- a/app/common/src/main/scala/io/scalajs/nodejs/zlib/Inflate.scala
+++ b/app/common/src/main/scala/io/scalajs/nodejs/zlib/Inflate.scala
@@ -5,7 +5,6 @@ import scala.scalajs.js
 
 /**
   * Decompress a deflate stream.
-  * @author lawrence.daniels@gmail.com
   */
 @js.native
 trait Inflate extends CompressionAlgorithm with stream.Readable

--- a/app/common/src/main/scala/io/scalajs/nodejs/zlib/InflateRaw.scala
+++ b/app/common/src/main/scala/io/scalajs/nodejs/zlib/InflateRaw.scala
@@ -5,7 +5,6 @@ import scala.scalajs.js
 
 /**
   * Decompress a raw deflate stream.
-  * @author lawrence.daniels@gmail.com
   */
 @js.native
 trait InflateRaw extends CompressionAlgorithm

--- a/app/common/src/main/scala/io/scalajs/nodejs/zlib/Unzip.scala
+++ b/app/common/src/main/scala/io/scalajs/nodejs/zlib/Unzip.scala
@@ -5,7 +5,6 @@ import scala.scalajs.js
 
 /**
   * Decompress a raw deflate stream.
-  * @author lawrence.daniels@gmail.com
   */
 @js.native
 trait Unzip extends CompressionAlgorithm

--- a/app/common/src/main/scala/io/scalajs/nodejs/zlib/Zlib.scala
+++ b/app/common/src/main/scala/io/scalajs/nodejs/zlib/Zlib.scala
@@ -12,7 +12,6 @@ import scala.scalajs.js.|
   * This provides bindings to Gzip/Gunzip, Deflate/Inflate, and DeflateRaw/InflateRaw classes.
   * Each class takes the same options, and is a readable/writable Stream.
   * @see https://nodejs.org/docs/latest/api/zlib.html
-  * @author lawrence.daniels@gmail.com
   */
 @js.native
 trait Zlib extends IEventEmitter {
@@ -266,7 +265,6 @@ trait Zlib extends IEventEmitter {
 
 /**
   * Zlib Singleton
-  * @author lawrence.daniels@gmail.com
   */
 @js.native
 @JSImport("zlib", JSImport.Namespace)

--- a/app/common/src/main/scala/io/scalajs/nodejs/zlib/package.scala
+++ b/app/common/src/main/scala/io/scalajs/nodejs/zlib/package.scala
@@ -9,7 +9,6 @@ import scala.scalajs.js.|
 
 /**
   * zlib package object
-  * @author lawrence.daniels@gmail.com
   */
 package object zlib {
 
@@ -23,7 +22,6 @@ package object zlib {
 
   /**
     * Zlib Extensions
-    * @author lawrence.daniels@gmail.com
     */
   final implicit class ZlibExtensions(val zlib: Zlib) extends AnyVal {
 

--- a/app/common/src/test/scala/io/scalajs/nodejs/AssertTest.scala
+++ b/app/common/src/test/scala/io/scalajs/nodejs/AssertTest.scala
@@ -6,7 +6,6 @@ import scala.scalajs.js
 
 /**
   * Assert Test
-  * @author lawrence.daniels@gmail.com
   */
 class AssertTest extends FunSpec {
 

--- a/app/common/src/test/scala/io/scalajs/nodejs/ProcessTest.scala
+++ b/app/common/src/test/scala/io/scalajs/nodejs/ProcessTest.scala
@@ -8,7 +8,6 @@ import scala.scalajs.js
 
 /**
   * Process Tests
-  * @author lawrence.daniels@gmail.com
   */
 class ProcessTest extends FunSpec {
 

--- a/app/common/src/test/scala/io/scalajs/nodejs/StringDecoderTest.scala
+++ b/app/common/src/test/scala/io/scalajs/nodejs/StringDecoderTest.scala
@@ -5,7 +5,6 @@ import org.scalatest.FunSpec
 
 /**
   * StringDecoder Tests
-  * @author lawrence.daniels@gmail.com
   */
 class StringDecoderTest extends FunSpec {
 

--- a/app/common/src/test/scala/io/scalajs/nodejs/buffer/BufferTest.scala
+++ b/app/common/src/test/scala/io/scalajs/nodejs/buffer/BufferTest.scala
@@ -7,7 +7,6 @@ import scala.scalajs.js
 
 /**
   * Buffer Tests
-  * @author lawrence.daniels@gmail.com
   */
 class BufferTest extends FunSpec {
 

--- a/app/common/src/test/scala/io/scalajs/nodejs/child_process/ChildProcessTest.scala
+++ b/app/common/src/test/scala/io/scalajs/nodejs/child_process/ChildProcessTest.scala
@@ -10,7 +10,6 @@ import scala.scalajs.js.|
 /**
   * ChildProcess Test
   *
-  * @author lawrence.daniels@gmail.com
   */
 class ChildProcessTest extends FunSpec {
 

--- a/app/common/src/test/scala/io/scalajs/nodejs/cluster/ClusterTest.scala
+++ b/app/common/src/test/scala/io/scalajs/nodejs/cluster/ClusterTest.scala
@@ -10,7 +10,6 @@ import scala.scalajs.js
 
 /**
   * Cluster Tests
-  * @author lawrence.daniels@gmail.com
   */
 class ClusterTest extends FunSpec {
 

--- a/app/common/src/test/scala/io/scalajs/nodejs/crypto/CryptoTest.scala
+++ b/app/common/src/test/scala/io/scalajs/nodejs/crypto/CryptoTest.scala
@@ -4,7 +4,6 @@ import org.scalatest.{FunSpec, MustMatchers}
 
 /**
   * Crypto Test
-  * @author lawrence.daniels@gmail.com
   */
 class CryptoTest extends FunSpec with MustMatchers {
 

--- a/app/common/src/test/scala/io/scalajs/nodejs/dns/DNSTest.scala
+++ b/app/common/src/test/scala/io/scalajs/nodejs/dns/DNSTest.scala
@@ -9,7 +9,6 @@ import scala.scalajs.js
 
 /**
   * DNS Tests
-  * @author lawrence.daniels@gmail.com
   */
 class DNSTest extends FunSpec {
   private val domain = "yahoo.com"

--- a/app/common/src/test/scala/io/scalajs/nodejs/events/EventEmitterTest.scala
+++ b/app/common/src/test/scala/io/scalajs/nodejs/events/EventEmitterTest.scala
@@ -7,7 +7,6 @@ import scala.scalajs.js
 
 /**
   * EventEmitter Tests
-  * @author lawrence.daniels@gmail.com
   */
 class EventEmitterTest extends FunSpec {
 

--- a/app/common/src/test/scala/io/scalajs/nodejs/http/HttpTest.scala
+++ b/app/common/src/test/scala/io/scalajs/nodejs/http/HttpTest.scala
@@ -7,7 +7,6 @@ import scala.scalajs.js
 
 /**
   * Http Tests
-  * @author lawrence.daniels@gmail.com
   */
 class HttpTest extends FunSpec {
 

--- a/app/common/src/test/scala/io/scalajs/nodejs/net/NetTest.scala
+++ b/app/common/src/test/scala/io/scalajs/nodejs/net/NetTest.scala
@@ -4,7 +4,6 @@ import org.scalatest.FunSpec
 
 /**
   * Network (Net) Tests
-  * @author lawrence.daniels@gmail.com
   */
 class NetTest extends FunSpec {
 

--- a/app/common/src/test/scala/io/scalajs/nodejs/os/OSTest.scala
+++ b/app/common/src/test/scala/io/scalajs/nodejs/os/OSTest.scala
@@ -6,7 +6,6 @@ import org.scalatest.FunSpec
 
 /**
   * OS Tests
-  * @author lawrence.daniels@gmail.com
   */
 class OSTest extends FunSpec {
 

--- a/app/common/src/test/scala/io/scalajs/nodejs/path/PathTest.scala
+++ b/app/common/src/test/scala/io/scalajs/nodejs/path/PathTest.scala
@@ -4,7 +4,6 @@ import org.scalatest.FunSpec
 
 /**
   * Path Tests
-  * @author lawrence.daniels@gmail.com
   */
 class PathTest extends FunSpec {
 

--- a/app/common/src/test/scala/io/scalajs/nodejs/querystring/QueryStringTest.scala
+++ b/app/common/src/test/scala/io/scalajs/nodejs/querystring/QueryStringTest.scala
@@ -9,7 +9,6 @@ import scala.scalajs.js
 
 /**
   * Query String Test
-  * @author lawrence.daniels@gmail.com
   */
 class QueryStringTest extends FunSpec {
 
@@ -51,7 +50,6 @@ class QueryStringTest extends FunSpec {
 
 /**
   * Query String Test Companion
-  * @author lawrence.daniels@gmail.com
   */
 object QueryStringTest {
 

--- a/app/common/src/test/scala/io/scalajs/nodejs/tty/TTYTest.scala
+++ b/app/common/src/test/scala/io/scalajs/nodejs/tty/TTYTest.scala
@@ -4,7 +4,6 @@ import org.scalatest.FunSpec
 
 /**
   * TTY Test
-  * @author lawrence.daniels@gmail.com
   */
 class TTYTest extends FunSpec {
 

--- a/app/common/src/test/scala/io/scalajs/nodejs/vm/VMTest.scala
+++ b/app/common/src/test/scala/io/scalajs/nodejs/vm/VMTest.scala
@@ -7,7 +7,6 @@ import scala.scalajs.js
 
 /**
   * VM Tests
-  * @author lawrence.daniels@gmail.com
   */
 class VMTest extends FunSpec {
 
@@ -49,7 +48,6 @@ class VMTest extends FunSpec {
 
 /**
   * VM Test Companion
-  * @author lawrence.daniels@gmail.com
   */
 object VMTest {
 

--- a/app/common/src/test/scala/io/scalajs/nodejs/zlib/ZlibTest.scala
+++ b/app/common/src/test/scala/io/scalajs/nodejs/zlib/ZlibTest.scala
@@ -7,7 +7,6 @@ import scala.scalajs.concurrent.JSExecutionContext.Implicits.queue
 
 /**
   * Zlib Tests
-  * @author lawrence.daniels@gmail.com
   */
 class ZlibTest extends FunSpec {
 

--- a/app/nodejs_v8/src/main/scala/io/scalajs/nodejs/fs/Fs.scala
+++ b/app/nodejs_v8/src/main/scala/io/scalajs/nodejs/fs/Fs.scala
@@ -21,7 +21,6 @@ import scala.scalajs.js.|
   *
   * When using the synchronous form any exceptions are immediately thrown. You can use try/catch to handle exceptions
   * or allow them to bubble up.
-  * @author lawrence.daniels@gmail.com
   */
 @js.native
 trait Fs extends IEventEmitter with FSConstants {
@@ -1128,7 +1127,6 @@ trait Fs extends IEventEmitter with FSConstants {
 
 /**
   * File System Singleton
-  * @author lawrence.daniels@gmail.com
   */
 @js.native
 @JSImport("fs", JSImport.Namespace)
@@ -1136,7 +1134,6 @@ object Fs extends Fs
 
 /**
   * File Append Options
-  * @author lawrence.daniels@gmail.com
   */
 class FileAppendOptions(val encoding: js.UndefOr[String] = js.undefined,
                         val mode: js.UndefOr[FileMode] = js.undefined,
@@ -1145,13 +1142,11 @@ class FileAppendOptions(val encoding: js.UndefOr[String] = js.undefined,
 
 /**
   * File Encoding Options
-  * @author lawrence.daniels@gmail.com
   */
 class FileEncodingOptions(val encoding: js.UndefOr[String] = js.undefined) extends js.Object
 
 /**
   * File Input Options
-  * @author lawrence.daniels@gmail.com
   */
 class FileInputOptions(val flags: js.UndefOr[String] = js.undefined,
                        val encoding: js.UndefOr[String] = js.undefined,
@@ -1164,7 +1159,6 @@ class FileInputOptions(val flags: js.UndefOr[String] = js.undefined,
 
 /**
   * File Input Options
-  * @author lawrence.daniels@gmail.com
   */
 class FileOutputOptions(val flags: js.UndefOr[String] = js.undefined,
                         val defaultEncoding: js.UndefOr[String] = js.undefined,

--- a/app/nodejs_v8/src/main/scala/io/scalajs/nodejs/fs/package.scala
+++ b/app/nodejs_v8/src/main/scala/io/scalajs/nodejs/fs/package.scala
@@ -11,7 +11,6 @@ import scala.scalajs.js.|
 
 /**
   * fs package object
-  * @author lawrence.daniels@gmail.com
   */
 package object fs {
 

--- a/app/nodejs_v8/src/main/scala/io/scalajs/nodejs/url/URL.scala
+++ b/app/nodejs_v8/src/main/scala/io/scalajs/nodejs/url/URL.scala
@@ -12,7 +12,6 @@ import scala.scalajs.js.|
   * @param input The input URL to parse
   * @param base  The base URL to resolve against if the input is not absolute.
   * @see https://nodejs.org/api/url.html
-  * @author lawrence.daniels@gmail.com
   */
 @js.native
 @JSImport("url", "URL")
@@ -106,7 +105,6 @@ class URL(input: String, base: String | URL = js.native) extends js.Object {
 
 /**
   * This module has utilities for URL resolution and parsing. Call require('url') to use it.
-  * @author lawrence.daniels@gmail.com
   */
 @js.native
 @JSImport("url", JSImport.Namespace)

--- a/app/nodejs_v8/src/main/scala/io/scalajs/nodejs/url/URLObject.scala
+++ b/app/nodejs_v8/src/main/scala/io/scalajs/nodejs/url/URLObject.scala
@@ -4,7 +4,6 @@ import scala.scalajs.js
 
 /**
   * Parsed URL Object
-  * @author lawrence.daniels@gmail.com
   */
 @js.native
 trait URLObject extends js.Object {

--- a/app/nodejs_v8/src/main/scala/io/scalajs/nodejs/url/URLSearchParams.scala
+++ b/app/nodejs_v8/src/main/scala/io/scalajs/nodejs/url/URLSearchParams.scala
@@ -13,7 +13,6 @@ import scala.scalajs.js.|
   * The WHATWG URLSearchParams interface and the querystring module have similar purpose, but the purpose
   * of the querystring module is more general, as it allows the customization of delimiter characters (& and =).
   * On the other hand, this API is designed purely for URL query strings.
-  * @author lawrence.daniels@gmail.com
   */
 @js.native
 @JSImport("url", "URLSearchParams")

--- a/app/nodejs_v8/src/main/scala/io/scalajs/nodejs/url/package.scala
+++ b/app/nodejs_v8/src/main/scala/io/scalajs/nodejs/url/package.scala
@@ -7,7 +7,6 @@ import scala.scalajs.js.|
 
 /**
   * url package object
-  * @author lawrence.daniels@gmail.com
   */
 package object url {
 

--- a/app/nodejs_v8/src/test/scala/io/scalajs/nodejs/fs/FsTest.scala
+++ b/app/nodejs_v8/src/test/scala/io/scalajs/nodejs/fs/FsTest.scala
@@ -9,7 +9,6 @@ import org.scalatest.FunSpec
 /**
   * File System (Fs) Tests
   *
-  * @author lawrence.daniels@gmail.com
   */
 class FsTest extends FunSpec {
 

--- a/app/nodejs_v8/src/test/scala/io/scalajs/nodejs/readline/ReadlineTest.scala
+++ b/app/nodejs_v8/src/test/scala/io/scalajs/nodejs/readline/ReadlineTest.scala
@@ -6,7 +6,6 @@ import org.scalatest.FunSpec
 
 /**
   * Readline Tests
-  * @author lawrence.daniels@gmail.com
   */
 class ReadlineTest extends FunSpec {
 

--- a/app/nodejs_v8/src/test/scala/io/scalajs/nodejs/url/URLObjectTest.scala
+++ b/app/nodejs_v8/src/test/scala/io/scalajs/nodejs/url/URLObjectTest.scala
@@ -7,7 +7,6 @@ import org.scalatest.FunSpec
 
 /**
   * URLObject Tests
-  * @author lawrence.daniels@gmail.com
   */
 class URLObjectTest extends FunSpec {
 

--- a/app/nodejs_v8/src/test/scala/io/scalajs/nodejs/url/URLSearchParamsTest.scala
+++ b/app/nodejs_v8/src/test/scala/io/scalajs/nodejs/url/URLSearchParamsTest.scala
@@ -7,7 +7,6 @@ import scala.scalajs.js
 
 /**
   * URLSearchParams Tests
-  * @author lawrence.daniels@gmail.com
   */
 class URLSearchParamsTest extends FunSpec {
 

--- a/app/nodejs_v8/src/test/scala/io/scalajs/nodejs/url/URLTest.scala
+++ b/app/nodejs_v8/src/test/scala/io/scalajs/nodejs/url/URLTest.scala
@@ -5,7 +5,6 @@ import org.scalatest._
 
 /**
   * URL Tests
-  * @author lawrence.daniels@gmail.com
   */
 class URLTest extends FunSpec {
 

--- a/core/src/main/scala/io/scalajs/JSON.scala
+++ b/core/src/main/scala/io/scalajs/JSON.scala
@@ -8,7 +8,6 @@ import scala.scalajs.js.|
   * The JSON object contains methods for parsing JavaScript Object Notation (JSON) and converting values to JSON.
   * It can't be called or constructed, and aside from its two method properties it has no interesting functionality of its own.
   * @see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON
-  * @author lawrence.daniels@gmail.com
   */
 @js.native
 trait JSON extends js.Object {
@@ -46,7 +45,6 @@ trait JSON extends js.Object {
 
 /**
   * JSON Singleton Object
-  * @author lawrence.daniels@gmail.com
   */
 @js.native
 @JSGlobal("JSON")

--- a/core/src/main/scala/io/scalajs/collection/Iterator.scala
+++ b/core/src/main/scala/io/scalajs/collection/Iterator.scala
@@ -7,7 +7,6 @@ import scala.scalajs.js
   * such as what values are looped over in a for..of construct. Some built-in types are built-in iterables
   * with a default iteration behavior, such as Array or Map, while other types (such as Object) are not.
   * @see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols
-  * @author lawrence.daniels@gmail.com
   */
 @js.native
 trait Iterator[+A] extends js.Object {

--- a/core/src/main/scala/io/scalajs/collection/JsCollection.scala
+++ b/core/src/main/scala/io/scalajs/collection/JsCollection.scala
@@ -6,7 +6,6 @@ import scala.scalajs.js.annotation.JSBracketAccess
 
 /**
   * JavaScript Collection
-  * @author lawrence.daniels@gmail.com
   */
 @js.native
 trait JsCollection[A] extends js.Object {
@@ -29,7 +28,6 @@ trait JsCollection[A] extends js.Object {
 
 /**
   * JsCollection Companion
-  * @author lawrence.daniels@gmail.com
   */
 object JsCollection {
 

--- a/core/src/main/scala/io/scalajs/package.scala
+++ b/core/src/main/scala/io/scalajs/package.scala
@@ -5,7 +5,6 @@ import scala.scalajs.js.|
 
 /**
   * scalajs package object
-  * @author lawrence.daniels@gmail.com
   */
 package object scalajs {
 

--- a/core/src/main/scala/io/scalajs/util/DateHelper.scala
+++ b/core/src/main/scala/io/scalajs/util/DateHelper.scala
@@ -5,7 +5,6 @@ import scala.scalajs.js
 
 /**
   * Date Helper
-  * @author lawrence.daniels@gmail.com
   */
 object DateHelper {
 

--- a/core/src/main/scala/io/scalajs/util/DurationHelper.scala
+++ b/core/src/main/scala/io/scalajs/util/DurationHelper.scala
@@ -4,7 +4,6 @@ import scala.concurrent.duration._
 
 /**
   * Duration Helper
-  * @author lawrence.daniels@gmail.com
   */
 object DurationHelper {
 

--- a/core/src/main/scala/io/scalajs/util/JSONHelper.scala
+++ b/core/src/main/scala/io/scalajs/util/JSONHelper.scala
@@ -6,7 +6,6 @@ import scala.scalajs.js
 
 /**
   * JSON Helper
-  * @author lawrence.daniels@gmail.com
   */
 object JSONHelper {
 

--- a/core/src/main/scala/io/scalajs/util/JsUnderOrHelper.scala
+++ b/core/src/main/scala/io/scalajs/util/JsUnderOrHelper.scala
@@ -5,7 +5,6 @@ import scala.scalajs.js.JSConverters._
 
 /**
   * js.UnderOr Helper
-  * @author lawrence.daniels@gmail.com
   */
 object JsUnderOrHelper {
 

--- a/core/src/main/scala/io/scalajs/util/MacroHelper.scala
+++ b/core/src/main/scala/io/scalajs/util/MacroHelper.scala
@@ -4,7 +4,6 @@ import scala.reflect.macros.blackbox
 
 /**
   * Macro Helper
-  * @author lawrence.daniels@gmail.com
   */
 object MacroHelper {
 

--- a/core/src/main/scala/io/scalajs/util/OptionHelper.scala
+++ b/core/src/main/scala/io/scalajs/util/OptionHelper.scala
@@ -6,7 +6,6 @@ import scala.scalajs.js
 
 /**
   * Option Helper
-  * @author lawrence.daniels@gmail.com
   */
 object OptionHelper {
 

--- a/core/src/main/scala/io/scalajs/util/PromiseHelper.scala
+++ b/core/src/main/scala/io/scalajs/util/PromiseHelper.scala
@@ -7,7 +7,6 @@ import scala.util.{Failure, Success}
 
 /**
   * Promise Helper
-  * @author lawrence.daniels@gmail.com
   */
 object PromiseHelper {
 
@@ -285,7 +284,6 @@ object PromiseHelper {
 
   /**
     * Implicit conversion
-    * @author lawrence.daniels@gmail.com
     */
   object Implicits {
 

--- a/core/src/main/scala/io/scalajs/util/ScalaJsHelper.scala
+++ b/core/src/main/scala/io/scalajs/util/ScalaJsHelper.scala
@@ -6,7 +6,6 @@ import scala.scalajs.js
 
 /**
   * ScalaJS Convenience Helper Functions
-  * @author lawrence.daniels@gmail.com
   */
 object ScalaJsHelper {
 

--- a/core/src/test/scala/io/scalajs/JSONTest.scala
+++ b/core/src/test/scala/io/scalajs/JSONTest.scala
@@ -6,7 +6,6 @@ import scala.scalajs.js
 
 /**
   * JSON Test
-  * @author lawrence.daniels@gmail.com
   */
 class JSONTest extends FunSpec {
 


### PR DESCRIPTION
Since this is a fork, any report to the original author regarding this fork may beannoying them.

And, maintenancing `@author` annotation is non-neligible task, I think.
I (and future contributors) may slip updating annotations then.
I don't spend time for updating author annotations, since authors can be tracked via git commit histories.

So, in this repo, no `@author` will be used.