### PR TITLE
Migrate to scalatest new fashion

### DIFF
--- a/app/current/src/test/scala/io/scalajs/nodejs/TopLevelTest.scala
+++ b/app/current/src/test/scala/io/scalajs/nodejs/TopLevelTest.scala
@@ -1,10 +1,9 @@
 package io.scalajs.nodejs
 
-import org.scalatest.FunSuite
-
 import scala.scalajs.js
+import org.scalatest.funsuite.AnyFunSuite
 
-class TopLevelTest extends FunSuite {
+class TopLevelTest extends AnyFunSuite {
   test("queueMicrotask") {
     assert(queueMicrotask.isInstanceOf[js.Function])
     queueMicrotask(() => println("printed from queueMicrotask"))

--- a/app/current/src/test/scala/io/scalajs/nodejs/buffer/BufferTest.scala
+++ b/app/current/src/test/scala/io/scalajs/nodejs/buffer/BufferTest.scala
@@ -1,13 +1,12 @@
 package io.scalajs.nodejs.buffer
 
-import org.scalatest.FunSpec
-
 import scala.scalajs.js
+import org.scalatest.funspec.AnyFunSpec
 
 /**
   * Buffer Tests
   */
-class BufferTest extends FunSpec {
+class BufferTest extends AnyFunSpec {
   it("should support writeBigInt64BE, writeBigInt64LE, writeBigInt64BE and writeBigInt64BE") {
     val buf = Buffer.allocUnsafe(8)
     val v   = js.BigInt("0x0102030405060708")

--- a/app/current/src/test/scala/io/scalajs/nodejs/fs/FsAsyncTest.scala
+++ b/app/current/src/test/scala/io/scalajs/nodejs/fs/FsAsyncTest.scala
@@ -1,8 +1,9 @@
 package io.scalajs.nodejs.fs
 
-import org.scalatest.{AsyncFunSpec, BeforeAndAfterEach}
+import org.scalatest.BeforeAndAfterEach
 
 import scala.concurrent.ExecutionContext
+import org.scalatest.funspec.AsyncFunSpec
 
 class FsAsyncTest extends AsyncFunSpec with BeforeAndAfterEach {
   override implicit val executionContext = ExecutionContext.Implicits.global

--- a/app/current/src/test/scala/io/scalajs/nodejs/fs/FsClassesTest.scala
+++ b/app/current/src/test/scala/io/scalajs/nodejs/fs/FsClassesTest.scala
@@ -1,12 +1,12 @@
 package io.scalajs.nodejs.fs
 
-import org.scalatest.FunSpec
+import org.scalatest.funspec.AnyFunSpec
 
 /**
   * File System (Fs) Tests
   *
   */
-class FsClassesTest extends FunSpec {
+class FsClassesTest extends AnyFunSpec {
   describe("ReadStream") {
     it("supports pending added in v11.2.0") {
       assert(new ReadStream("package.json").pending)

--- a/app/nodejs-v10/src/test/scala/io/scalajs/nodejs/AssertTest.scala
+++ b/app/nodejs-v10/src/test/scala/io/scalajs/nodejs/AssertTest.scala
@@ -1,13 +1,12 @@
 package io.scalajs.nodejs
 
-import org.scalatest.FunSpec
-
 import scala.scalajs.js
+import org.scalatest.funspec.AnyFunSpec
 
 /**
   * Assert Test
   */
-class AssertTest extends FunSpec {
+class AssertTest extends AnyFunSpec {
   describe("Assert") {
     it("should handle deep comparisons") {
       Assert.deepStrictEqual(js.Array(1, 2, 3), js.Array(1, 2, 3))

--- a/app/nodejs-v10/src/test/scala/io/scalajs/nodejs/StringDecoderTest.scala
+++ b/app/nodejs-v10/src/test/scala/io/scalajs/nodejs/StringDecoderTest.scala
@@ -1,9 +1,9 @@
 package io.scalajs.nodejs
 
 import io.scalajs.nodejs.buffer.Buffer
-import org.scalatest.FunSpec
+import org.scalatest.funspec.AnyFunSpec
 
-class StringDecoderTest extends FunSpec {
+class StringDecoderTest extends AnyFunSpec {
   describe("StringDecoder") {
     it("should decode strings or buffer") {
       val decoder = new StringDecoder("utf8")

--- a/app/nodejs-v10/src/test/scala/io/scalajs/nodejs/assertion/AssertTest.scala
+++ b/app/nodejs-v10/src/test/scala/io/scalajs/nodejs/assertion/AssertTest.scala
@@ -1,11 +1,11 @@
 package io.scalajs.nodejs.assertion
 
-import org.scalatest.FunSpec
 import io.scalajs.nodejs.{Assert => NodeAssert}
 
 import scala.scalajs.js
+import org.scalatest.funspec.AnyFunSpec
 
-class AssertTest extends FunSpec {
+class AssertTest extends AnyFunSpec {
   it("have strict from v9.9.0") {
     assert(NodeAssert.strict !== js.undefined)
   }

--- a/app/nodejs-v10/src/test/scala/io/scalajs/nodejs/buffer/BufferTest.scala
+++ b/app/nodejs-v10/src/test/scala/io/scalajs/nodejs/buffer/BufferTest.scala
@@ -1,12 +1,12 @@
 package io.scalajs.nodejs.buffer
 
 import io.scalajs.nodejs.{TestEnvironment, buffer}
-import org.scalatest.FunSpec
 
 import scala.scalajs.js
 import scala.scalajs.js.typedarray.{ArrayBuffer, DataView, Uint8Array}
+import org.scalatest.funspec.AnyFunSpec
 
-class BufferTest extends FunSpec {
+class BufferTest extends AnyFunSpec {
   describe("Buffer") {
     describe("instance members") {
       it("should sort buffers") {

--- a/app/nodejs-v10/src/test/scala/io/scalajs/nodejs/child_process/ChildProcessTest.scala
+++ b/app/nodejs-v10/src/test/scala/io/scalajs/nodejs/child_process/ChildProcessTest.scala
@@ -4,11 +4,11 @@ package child_process
 import io.scalajs.nodejs.buffer.Buffer
 import io.scalajs.util.ScalaJsHelper._
 import io.scalajs.util.NodeJSConverters._
-import org.scalatest.AsyncFunSpec
 
 import scala.concurrent.{ExecutionContext, Promise}
 import scala.scalajs.js
 import scala.scalajs.js.|
+import org.scalatest.funspec.AsyncFunSpec
 
 /**
   * ChildProcess Test

--- a/app/nodejs-v10/src/test/scala/io/scalajs/nodejs/cluster/ClusterTest.scala
+++ b/app/nodejs-v10/src/test/scala/io/scalajs/nodejs/cluster/ClusterTest.scala
@@ -1,12 +1,12 @@
 package io.scalajs.nodejs.cluster
 
 import io.scalajs.nodejs.setTimeout
-import org.scalatest.FunSpec
 
 import scala.concurrent.duration._
 import scala.scalajs.js
+import org.scalatest.funspec.AnyFunSpec
 
-class ClusterTest extends FunSpec {
+class ClusterTest extends AnyFunSpec {
   describe("Cluster") {
     it("cluster should be master") {
       assert(Cluster.isMaster)

--- a/app/nodejs-v10/src/test/scala/io/scalajs/nodejs/console_module/ConsoleTest.scala
+++ b/app/nodejs-v10/src/test/scala/io/scalajs/nodejs/console_module/ConsoleTest.scala
@@ -1,11 +1,12 @@
 package io.scalajs.nodejs.console_module
 
 import io.scalajs.nodejs.fs.Fs
-import org.scalatest.{BeforeAndAfterEach, FunSpec}
+import org.scalatest.BeforeAndAfterEach
 
 import scala.scalajs.js
+import org.scalatest.funspec.AnyFunSpec
 
-class ConsoleTest extends FunSpec with BeforeAndAfterEach {
+class ConsoleTest extends AnyFunSpec with BeforeAndAfterEach {
   private val logFileName = "x.nodejs10.ConsoleTest"
 
   override def afterEach(): Unit = {

--- a/app/nodejs-v10/src/test/scala/io/scalajs/nodejs/console_module/ConsoleV8Test.scala
+++ b/app/nodejs-v10/src/test/scala/io/scalajs/nodejs/console_module/ConsoleV8Test.scala
@@ -2,11 +2,12 @@ package io.scalajs.nodejs.console_module
 
 import io.scalajs.nodejs.TestEnvironment
 import io.scalajs.nodejs.fs.{Fs, WriteStream}
-import org.scalatest.{BeforeAndAfterEach, FunSpec}
+import org.scalatest.BeforeAndAfterEach
 
 import scala.scalajs.js.JavaScriptException
+import org.scalatest.funspec.AnyFunSpec
 
-class ConsoleV8Test extends FunSpec with BeforeAndAfterEach {
+class ConsoleV8Test extends AnyFunSpec with BeforeAndAfterEach {
   private val logFileName                  = "x.nodejs8.ConsoleTest"
   private var failingWritable: WriteStream = null
 

--- a/app/nodejs-v10/src/test/scala/io/scalajs/nodejs/crypto/CertificateTest.scala
+++ b/app/nodejs-v10/src/test/scala/io/scalajs/nodejs/crypto/CertificateTest.scala
@@ -1,9 +1,10 @@
 package io.scalajs.nodejs.crypto
 
 import io.scalajs.nodejs.buffer.Buffer
-import org.scalatest.{FunSpec, MustMatchers}
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.must.Matchers
 
-class CertificateTest extends FunSpec with MustMatchers {
+class CertificateTest extends AnyFunSpec with Matchers {
   val spkacExample =
     "MIIBXjCByDCBnzANBgkqhkiG9w0BAQEFAAOBjQAwgYkCgYEA3L0IfUijj7+A8CPC8EmhcdNoe5fUAog7OrBdhn7EkxFButUp40P7+LiYiygYG1TmoI/a5EgsLU3s9twEz3hmgY9mYIqb/rb+SF8qlD/K6KVyUORC7Wlz1Df4L8O3DuRGzx6/+3jIW6cPBpfgH1sVuYS1vDBsP/gMMIxwTsKJ4P0CAwEAARYkYzBkZjFlYjctMTU0NC00MWVkLWFmN2EtZDRkYjBkNDc5ZjZmMA0GCSqGSIb3DQEBBAUAA4GBALEiapUjaIPs5uEdvCP0gFK2qofo+4GpeK1A43mu28lirYPAvCWsmYvKIZIT9TxvzmQIxAfxobf70aSNlSm6MJJKmvurAK+Bpn6ZUKQZ6A1m927LvctVSYJuUi+WVmr0fGE/OfdQ+BqSm/eQ3jnm3fBPVx1uwLPgjC5g4EvGMh8M"
 

--- a/app/nodejs-v10/src/test/scala/io/scalajs/nodejs/crypto/CryptoTest.scala
+++ b/app/nodejs-v10/src/test/scala/io/scalajs/nodejs/crypto/CryptoTest.scala
@@ -1,12 +1,13 @@
 package io.scalajs.nodejs.crypto
 
 import io.scalajs.nodejs.buffer.Buffer
-import org.scalatest.{FunSpec, MustMatchers}
 
 import scala.scalajs.js
 import scala.scalajs.js.typedarray.{DataView, _}
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.must.Matchers
 
-class CryptoTest extends FunSpec with MustMatchers {
+class CryptoTest extends AnyFunSpec with Matchers {
   val spkacExample =
     "MIIBXjCByDCBnzANBgkqhkiG9w0BAQEFAAOBjQAwgYkCgYEA3L0IfUijj7+A8CPC8EmhcdNoe5fUAog7OrBdhn7EkxFButUp40P7+LiYiygYG1TmoI/a5EgsLU3s9twEz3hmgY9mYIqb/rb+SF8qlD/K6KVyUORC7Wlz1Df4L8O3DuRGzx6/+3jIW6cPBpfgH1sVuYS1vDBsP/gMMIxwTsKJ4P0CAwEAARYkYzBkZjFlYjctMTU0NC00MWVkLWFmN2EtZDRkYjBkNDc5ZjZmMA0GCSqGSIb3DQEBBAUAA4GBALEiapUjaIPs5uEdvCP0gFK2qofo+4GpeK1A43mu28lirYPAvCWsmYvKIZIT9TxvzmQIxAfxobf70aSNlSm6MJJKmvurAK+Bpn6ZUKQZ6A1m927LvctVSYJuUi+WVmr0fGE/OfdQ+BqSm/eQ3jnm3fBPVx1uwLPgjC5g4EvGMh8M"
 

--- a/app/nodejs-v10/src/test/scala/io/scalajs/nodejs/dns/DNSAsyncTest.scala
+++ b/app/nodejs-v10/src/test/scala/io/scalajs/nodejs/dns/DNSAsyncTest.scala
@@ -1,10 +1,9 @@
 package io.scalajs.nodejs
 package dns
 
-import org.scalatest.AsyncFunSpec
-
 import scala.concurrent.{ExecutionContext, Promise}
 import scala.scalajs.js
+import org.scalatest.funspec.AsyncFunSpec
 
 /**
   * DNS Tests

--- a/app/nodejs-v10/src/test/scala/io/scalajs/nodejs/events/EventEmitterTest.scala
+++ b/app/nodejs-v10/src/test/scala/io/scalajs/nodejs/events/EventEmitterTest.scala
@@ -1,9 +1,8 @@
 package io.scalajs.nodejs.events
 
-import org.scalatest.AsyncFunSpec
-
 import scala.concurrent.{ExecutionContext, Promise}
 import scala.scalajs.js
+import org.scalatest.funspec.AsyncFunSpec
 
 class EventEmitterTest extends AsyncFunSpec {
   override implicit val executionContext = ExecutionContext.Implicits.global

--- a/app/nodejs-v10/src/test/scala/io/scalajs/nodejs/fs/FsAsyncTest.scala
+++ b/app/nodejs-v10/src/test/scala/io/scalajs/nodejs/fs/FsAsyncTest.scala
@@ -1,8 +1,9 @@
 package io.scalajs.nodejs.fs
 
-import org.scalatest.{AsyncFunSpec, BeforeAndAfterEach}
+import org.scalatest.BeforeAndAfterEach
 
 import scala.concurrent.ExecutionContext
+import org.scalatest.funspec.AsyncFunSpec
 
 class FsAsyncTest extends AsyncFunSpec with BeforeAndAfterEach {
   override implicit val executionContext = ExecutionContext.Implicits.global

--- a/app/nodejs-v10/src/test/scala/io/scalajs/nodejs/fs/FsTest.scala
+++ b/app/nodejs-v10/src/test/scala/io/scalajs/nodejs/fs/FsTest.scala
@@ -3,9 +3,9 @@ package io.scalajs.nodejs.fs
 import io.scalajs.nodejs.setImmediate
 import io.scalajs.util.NodeJSConverters._
 import io.scalajs.util.ScalaJsHelper._
-import org.scalatest.AsyncFunSpec
 
 import scala.concurrent.{ExecutionContext, Promise}
+import org.scalatest.funspec.AsyncFunSpec
 
 /**
   * File System (Fs) Tests

--- a/app/nodejs-v10/src/test/scala/io/scalajs/nodejs/fs/FsV8AsyncTest.scala
+++ b/app/nodejs-v10/src/test/scala/io/scalajs/nodejs/fs/FsV8AsyncTest.scala
@@ -1,10 +1,11 @@
 package io.scalajs.nodejs.fs
 
 import io.scalajs.nodejs.buffer.Buffer
-import org.scalatest.{AsyncFunSpec, BeforeAndAfterEach}
+import org.scalatest.BeforeAndAfterEach
 
 import scala.concurrent.{ExecutionContext, Future}
 import scala.util.{Failure, Success}
+import org.scalatest.funspec.AsyncFunSpec
 
 class FsV8AsyncTest extends AsyncFunSpec with BeforeAndAfterEach {
   private val file = "x.File.txt"

--- a/app/nodejs-v10/src/test/scala/io/scalajs/nodejs/fs/ReadStreamTest.scala
+++ b/app/nodejs-v10/src/test/scala/io/scalajs/nodejs/fs/ReadStreamTest.scala
@@ -3,9 +3,9 @@ package fs
 
 import io.scalajs.nodejs.buffer.Buffer
 import io.scalajs.nodejs.url.URL
-import org.scalatest.FunSpec
+import org.scalatest.funspec.AnyFunSpec
 
-class FsClassesTest extends FunSpec {
+class FsClassesTest extends AnyFunSpec {
   val dirname = process.Process.cwd()
 
   describe("ReadStream") {

--- a/app/nodejs-v10/src/test/scala/io/scalajs/nodejs/http/HttpTest.scala
+++ b/app/nodejs-v10/src/test/scala/io/scalajs/nodejs/http/HttpTest.scala
@@ -1,14 +1,13 @@
 package io.scalajs.nodejs
 package http
 
-import org.scalatest.FunSpec
-
 import scala.scalajs.js
+import org.scalatest.funspec.AnyFunSpec
 
 /**
   * Http Tests
   */
-class HttpTest extends FunSpec {
+class HttpTest extends AnyFunSpec {
   describe("Http") {
     it("should provide an HTTP server") {
       val server = Http.createServer((request: ClientRequest, response: ServerResponse) => {

--- a/app/nodejs-v10/src/test/scala/io/scalajs/nodejs/http/StatusCodeTest.scala
+++ b/app/nodejs-v10/src/test/scala/io/scalajs/nodejs/http/StatusCodeTest.scala
@@ -1,13 +1,12 @@
 package io.scalajs.nodejs.http
 
-import org.scalatest.FunSpec
-
 import scala.scalajs.js
+import org.scalatest.funspec.AnyFunSpec
 
 /**
   * Http Tests
   */
-class StatusCodeTest extends FunSpec {
+class StatusCodeTest extends AnyFunSpec {
   describe("Http") {
     it("should provide an HTTP server") {
       val server = Http.createServer((request: ClientRequest, response: ServerResponse) => {

--- a/app/nodejs-v10/src/test/scala/io/scalajs/nodejs/http2/Http2HeadersTest.scala
+++ b/app/nodejs-v10/src/test/scala/io/scalajs/nodejs/http2/Http2HeadersTest.scala
@@ -1,10 +1,9 @@
 package io.scalajs.nodejs.http2
 
-import org.scalatest.FunSpec
-
 import scala.scalajs.js
+import org.scalatest.funspec.AnyFunSpec
 
-class Http2HeadersTest extends FunSpec {
+class Http2HeadersTest extends AnyFunSpec {
   describe("Http2Headers") {
     it("should treat JS name") {
       val headers = Http2Headers.forIncoming(

--- a/app/nodejs-v10/src/test/scala/io/scalajs/nodejs/net/NetTest.scala
+++ b/app/nodejs-v10/src/test/scala/io/scalajs/nodejs/net/NetTest.scala
@@ -1,11 +1,11 @@
 package io.scalajs.nodejs.net
 
-import org.scalatest.FunSpec
+import org.scalatest.funspec.AnyFunSpec
 
 /**
   * Network (Net) Tests
   */
-class NetTest extends FunSpec {
+class NetTest extends AnyFunSpec {
   describe("Net") {
     /*
     it("provides client-server connectivity") {

--- a/app/nodejs-v10/src/test/scala/io/scalajs/nodejs/os/OSTest.scala
+++ b/app/nodejs-v10/src/test/scala/io/scalajs/nodejs/os/OSTest.scala
@@ -1,12 +1,12 @@
 package io.scalajs.nodejs.os
 
 import io.scalajs.util.ScalaJsHelper._
-import org.scalatest.FunSpec
+import org.scalatest.funspec.AnyFunSpec
 
 /**
   * OS Tests
   */
-class OSTest extends FunSpec {
+class OSTest extends AnyFunSpec {
   describe("OS") {
     it("supports arch()") {
       assert(OS.arch().nonEmpty)

--- a/app/nodejs-v10/src/test/scala/io/scalajs/nodejs/path/PathTest.scala
+++ b/app/nodejs-v10/src/test/scala/io/scalajs/nodejs/path/PathTest.scala
@@ -1,9 +1,9 @@
 package io.scalajs.nodejs
 package path
 
-import org.scalatest.FunSpec
+import org.scalatest.funspec.AnyFunSpec
 
-class PathTest extends FunSpec {
+class PathTest extends AnyFunSpec {
   describe("Path") {
     it("supports basename()") {
       assert(Path.basename("/foo/bar/baz/asdf/quux.html") === "quux.html")

--- a/app/nodejs-v10/src/test/scala/io/scalajs/nodejs/process/EnvironmentTest.scala
+++ b/app/nodejs-v10/src/test/scala/io/scalajs/nodejs/process/EnvironmentTest.scala
@@ -1,8 +1,8 @@
 package io.scalajs.nodejs.process
 
-import org.scalatest.FunSpec
+import org.scalatest.funspec.AnyFunSpec
 
-class EnvironmentTest extends FunSpec {
+class EnvironmentTest extends AnyFunSpec {
   describe("Environment") {
     it("have PATH as member") {
       assert(Process.env.PATH.nonEmpty)

--- a/app/nodejs-v10/src/test/scala/io/scalajs/nodejs/process/ProcessTest.scala
+++ b/app/nodejs-v10/src/test/scala/io/scalajs/nodejs/process/ProcessTest.scala
@@ -2,9 +2,9 @@ package io.scalajs.nodejs.process
 
 import io.scalajs.nodejs.os.OS
 import io.scalajs.nodejs.TestEnvironment
-import org.scalatest.FunSpec
+import org.scalatest.funspec.AnyFunSpec
 
-class ProcessTest extends FunSpec {
+class ProcessTest extends AnyFunSpec {
   describe("Process") {
     val versionPrefix =
       if (TestEnvironment.isExecutedInExactNode8) "v8."

--- a/app/nodejs-v10/src/test/scala/io/scalajs/nodejs/querystring/QueryStringTest.scala
+++ b/app/nodejs-v10/src/test/scala/io/scalajs/nodejs/querystring/QueryStringTest.scala
@@ -1,14 +1,14 @@
 package io.scalajs.nodejs.querystring
 
 import io.scalajs.nodejs.querystring.QueryStringTest.MyParams
-import org.scalatest.FunSpec
 
 import scala.scalajs.js
+import org.scalatest.funspec.AnyFunSpec
 
 /**
   * Query String Test
   */
-class QueryStringTest extends FunSpec {
+class QueryStringTest extends AnyFunSpec {
   describe("QueryString") {
     it("should escape(...)") {
       val result = QueryString.escape("""https://www.google.com/#q=node?key=1234""")

--- a/app/nodejs-v10/src/test/scala/io/scalajs/nodejs/readline/ReadlineTest.scala
+++ b/app/nodejs-v10/src/test/scala/io/scalajs/nodejs/readline/ReadlineTest.scala
@@ -2,9 +2,9 @@ package io.scalajs.nodejs.readline
 
 import io.scalajs.nodejs.fs.Fs
 import io.scalajs.nodejs.process.Process
-import org.scalatest.AsyncFunSpec
 
 import scala.concurrent.{ExecutionContext, Promise}
+import org.scalatest.funspec.AsyncFunSpec
 
 /**
   * Readline Tests

--- a/app/nodejs-v10/src/test/scala/io/scalajs/nodejs/tty/TTYTest.scala
+++ b/app/nodejs-v10/src/test/scala/io/scalajs/nodejs/tty/TTYTest.scala
@@ -1,11 +1,11 @@
 package io.scalajs.nodejs.tty
 
-import org.scalatest.FunSpec
+import org.scalatest.funspec.AnyFunSpec
 
 /**
   * TTY Test
   */
-class TTYTest extends FunSpec {
+class TTYTest extends AnyFunSpec {
   describe("TTY") {
     it("should identify TTY devices") {
       assert(!TTY.isatty(1))

--- a/app/nodejs-v10/src/test/scala/io/scalajs/nodejs/url/URLObjectTest.scala
+++ b/app/nodejs-v10/src/test/scala/io/scalajs/nodejs/url/URLObjectTest.scala
@@ -2,12 +2,12 @@ package io.scalajs.nodejs
 package url
 
 import io.scalajs.util.JSONHelper._
-import org.scalatest.FunSpec
+import org.scalatest.funspec.AnyFunSpec
 
 /**
   * URLObject Tests
   */
-class URLObjectTest extends FunSpec {
+class URLObjectTest extends AnyFunSpec {
   describe("URLObject") {
     val originalUrl = "https://www.google.com/webhp?sourceid=chrome-instant&ion=1&espv=2&ie=UTF-8#q=node"
     val urlObject   = new URL(originalUrl)

--- a/app/nodejs-v10/src/test/scala/io/scalajs/nodejs/url/URLSearchParamsTest.scala
+++ b/app/nodejs-v10/src/test/scala/io/scalajs/nodejs/url/URLSearchParamsTest.scala
@@ -1,10 +1,9 @@
 package io.scalajs.nodejs.url
 
-import org.scalatest.FunSpec
-
 import scala.scalajs.js
+import org.scalatest.funspec.AnyFunSpec
 
-class URLSearchParamsTest extends FunSpec {
+class URLSearchParamsTest extends AnyFunSpec {
   describe("URLSearchParams") {
     it("should parse the string as a query string") {
       val params = new URLSearchParams("user=abc&query=xyz")

--- a/app/nodejs-v10/src/test/scala/io/scalajs/nodejs/url/URLTest.scala
+++ b/app/nodejs-v10/src/test/scala/io/scalajs/nodejs/url/URLTest.scala
@@ -1,7 +1,6 @@
 package io.scalajs.nodejs
 package url
 
-import org.scalatest._
 import org.scalatest.funspec.AnyFunSpec
 
 class URLTest extends AnyFunSpec {

--- a/app/nodejs-v10/src/test/scala/io/scalajs/nodejs/url/URLTest.scala
+++ b/app/nodejs-v10/src/test/scala/io/scalajs/nodejs/url/URLTest.scala
@@ -2,8 +2,9 @@ package io.scalajs.nodejs
 package url
 
 import org.scalatest._
+import org.scalatest.funspec.AnyFunSpec
 
-class URLTest extends FunSpec {
+class URLTest extends AnyFunSpec {
   describe("URL") {
     it("Gets and sets the serialized query portion of the URL") {
       val myURL = new URL("https://example.org/abc?123")

--- a/app/nodejs-v10/src/test/scala/io/scalajs/nodejs/util/UtilTest.scala
+++ b/app/nodejs-v10/src/test/scala/io/scalajs/nodejs/util/UtilTest.scala
@@ -1,10 +1,9 @@
 package io.scalajs.nodejs.util
 
-import org.scalatest.FunSpec
-
 import scala.scalajs.js
+import org.scalatest.funspec.AnyFunSpec
 
-class UtilTest extends FunSpec {
+class UtilTest extends AnyFunSpec {
   it("have inspect object") {
     assert(Util.inspect !== null)
     assert(Util.inspect(js.Array(1, 2, 3)) === "[ 1, 2, 3 ]")

--- a/app/nodejs-v10/src/test/scala/io/scalajs/nodejs/vm/VMTest.scala
+++ b/app/nodejs-v10/src/test/scala/io/scalajs/nodejs/vm/VMTest.scala
@@ -1,14 +1,14 @@
 package io.scalajs.nodejs.vm
 
 import io.scalajs.nodejs.vm.VMTest.{ExpectedData, Sandbox}
-import org.scalatest.FunSpec
 
 import scala.scalajs.js
+import org.scalatest.funspec.AnyFunSpec
 
 /**
   * VM Tests
   */
-class VMTest extends FunSpec {
+class VMTest extends AnyFunSpec {
   describe("VM") {
     it("should compile and execute JavaScript code") {
       val sandbox = new Sandbox(animal = "cat", count = 2, name = "kitty")

--- a/app/nodejs-v10/src/test/scala/io/scalajs/nodejs/zlib/ZlibTest.scala
+++ b/app/nodejs-v10/src/test/scala/io/scalajs/nodejs/zlib/ZlibTest.scala
@@ -1,11 +1,11 @@
 package io.scalajs.nodejs.zlib
 
 import io.scalajs.nodejs.buffer.Buffer
-import org.scalatest.FunSpec
 
 import scala.scalajs.concurrent.JSExecutionContext.Implicits.queue
+import org.scalatest.funspec.AnyFunSpec
 
-class ZlibTest extends FunSpec {
+class ZlibTest extends AnyFunSpec {
   describe("Zlib") {
     it("should compress strings and buffers") {
       val original = Buffer.from("This is a compression example")


### PR DESCRIPTION
## Steps

1. Add `addSbtPlugin("ch.epfl.scala" % "sbt-scalafix" % "0.9.11")`
2. Run the below commands in sbt.
```
scalafixEnable
test:scalafix https://raw.githubusercontent.com/scalatest/autofix/e4de53fa40fac423bd64d165ff36bde38ce52388/3.0.x/rules/src/main/scala/org/scalatest/autofix/v3_0_x/RenameDeprecatedPackage.scala
test:scalafix https://raw.githubusercontent.com/scalatest/autofix/e4de53fa40fac423bd64d165ff36bde38ce52388/3.1.x/rules/src/main/scala/org/scalatest/autofix/v3_1_x/RewriteDeprecatedNames.scala
```