### PR TITLE
Fix "errors" module-related issues

### DIFF
--- a/app/current/src/main/scala/io/scalajs/nodejs/Error.scala
+++ b/app/current/src/main/scala/io/scalajs/nodejs/Error.scala
@@ -1,7 +1,7 @@
 package io.scalajs.nodejs
 
 import scala.scalajs.js
-import scala.scalajs.js.annotation.{JSGlobal, JSImport}
+import scala.scalajs.js.annotation.JSGlobal
 
 /**
   * Creates a new Error object and sets the error.message property to the provided text message.
@@ -12,7 +12,7 @@ import scala.scalajs.js.annotation.{JSGlobal, JSImport}
   * Error.stackTraceLimit, whichever is smaller.
   */
 @js.native
-@JSImport("errors", "Error")
+@JSGlobal
 class Error(message0: String = js.native) extends js.Object {
 
   /**

--- a/app/current/src/main/scala/io/scalajs/nodejs/SystemError.scala
+++ b/app/current/src/main/scala/io/scalajs/nodejs/SystemError.scala
@@ -1,15 +1,13 @@
 package io.scalajs.nodejs
 
 import scala.scalajs.js
-import scala.scalajs.js.annotation.JSImport
 import scala.scalajs.js.|
 
 /**
   * System Error
   */
 @js.native
-@JSImport("errors", "SystemError")
-class SystemError(message0: String = js.native) extends Error(message0) {
+trait SystemError extends Error {
 
   /**
     * The error.errno property is a number or a string. The number is a negative value which corresponds
@@ -44,13 +42,6 @@ class SystemError(message0: String = js.native) extends Error(message0) {
   val dest: String    = js.native
   val info: js.Object = js.native
 }
-
-/**
-  * System Error Singleton
-  */
-@js.native
-@JSImport("errors", JSImport.Namespace)
-object SystemError extends Error
 
 object SystemErrorCodes {
   @inline final val E2BIG           = "E2BIG"


### PR DESCRIPTION
* `Error` class and object is exposed globally
* `SystemError` is not exposed and newable

These are found while preparing for Scala.js 1.0 in #156 
It seems that Scala.js 0.6 do not complain about these issue in `errors` module, but Scala.js 1.0 do.

