### PR TITLE
[stream] Remove the unused class Chunk

### DIFF
--- a/app/current/src/main/scala/io/scalajs/nodejs/stream/Stream.scala
+++ b/app/current/src/main/scala/io/scalajs/nodejs/stream/Stream.scala
@@ -308,13 +308,6 @@ sealed trait IWritable extends LegacyStream {
   def write(chunk: String, encoding: String, callback: js.Function1[Error, Any]): Boolean        = js.native
 }
 
-/**
-  * Represents a chunk of data
-  * @param chunk    the chunk of data
-  * @param encoding the data's optional encoding
-  */
-class Chunk(var encoding: js.UndefOr[String] = js.undefined) extends js.Object
-
 class WritableOptions(var highWaterMark: js.UndefOr[Int] = js.undefined,
                       var decodeStrings: js.UndefOr[Boolean] = js.undefined,
                       var defaultEncoding: js.UndefOr[String] = js.undefined,


### PR DESCRIPTION
This was supposed to be used in _writev
https://nodejs.org/dist/latest-v12.x/docs/api/stream.html#stream_writable_writev_chunks_callback