### PR TITLE
[process] Deprecate process.openStdin in favor of process.stdin

### DIFF
--- a/app/current/src/main/scala/io/scalajs/nodejs/process/Process.scala
+++ b/app/current/src/main/scala/io/scalajs/nodejs/process/Process.scala
@@ -301,9 +301,7 @@ trait Process extends IEventEmitter {
     */
   def nextTick(callback: js.Function0[Any], args: js.Any*): Unit = js.native
 
-  /**
-    * TODO find documentation
-    */
+  @deprecated("Use process.stdin instead", "Node.js v0.3.3")
   def openStdin(): ReadStream = js.native
 
   /**


### PR DESCRIPTION
See https://github.com/nodejs/node/blob/43e4efdf210adb2cc3ba26518fd4588f9e0152ff/doc/changelogs/CHANGELOG_ARCHIVE.md#20110102-version-033-unstable