### PR TITLE
Use factory macro to reduce cost of maintaining factory methods

### DIFF
--- a/app/current/src/main/scala/io/scalajs/nodejs/cluster/ClusterSettings.scala
+++ b/app/current/src/main/scala/io/scalajs/nodejs/cluster/ClusterSettings.scala
@@ -1,5 +1,8 @@
 package io.scalajs.nodejs.cluster
 
+import com.thoughtworks.enableIf
+import net.exoego.scalajs.types.util.Factory
+
 import io.scalajs.nodejs.{GID, UID}
 
 import scala.scalajs.js
@@ -8,6 +11,7 @@ import scala.scalajs.js.|
 /**
   * Cluster Settings
   */
+@Factory
 @js.native
 trait ClusterSettings extends js.Object {
 
@@ -30,6 +34,7 @@ trait ClusterSettings extends js.Object {
     *
     * From Node.js v13.2.0, v12.16.0.
     */
+  @enableIf(io.scalajs.nodejs.internal.CompilerSwitches.gteNodeJs12)
   var serialization: String = js.native
 
   /** <Number> Sets the user identity of the process. (See setuid(2).) */
@@ -45,32 +50,4 @@ trait ClusterSettings extends js.Object {
   var cwd: String = js.native
 
   var windowsHide: Boolean = js.native
-}
-
-/**
-  * Cluster Settings Companion
-  */
-object ClusterSettings {
-  def apply(execArgv: js.Array[String] = null,
-            exec: String = null,
-            args: js.Array[String] = null,
-            silent: Boolean = false,
-            serialization: String = "json",
-            stdio: js.Array[js.Any] = null,
-            inspectPort: Int | js.Function = null,
-            cwd: String = null,
-            windowsHide: Boolean = false
-  ): ClusterSettings = {
-    val settings = js.Dynamic.literal()
-    settings.updateDynamic("execArgv")(execArgv)
-    settings.updateDynamic("exec")(exec)
-    settings.updateDynamic("args")(args)
-    settings.updateDynamic("silent")(silent)
-    settings.updateDynamic("serialization")(serialization)
-    settings.updateDynamic("stdio")(stdio)
-    settings.updateDynamic("inspectPort")(inspectPort.asInstanceOf[js.Any])
-    settings.updateDynamic("cwd")(cwd)
-    settings.updateDynamic("windowsHide")(windowsHide)
-    settings.asInstanceOf[ClusterSettings]
-  }
 }

--- a/app/current/src/main/scala/io/scalajs/nodejs/crypto/DiffieHellmanOptions.scala
+++ b/app/current/src/main/scala/io/scalajs/nodejs/crypto/DiffieHellmanOptions.scala
@@ -1,21 +1,10 @@
 package io.scalajs.nodejs.crypto
 
 import scala.scalajs.js
+import net.exoego.scalajs.types.util.Factory
 
+@Factory
 trait DiffieHellmanOptions {
   var privateKey: KeyObject
   var publicKey: KeyObject
-}
-
-object DiffieHellmanOptions {
-  def apply(
-      privateKey: KeyObject,
-      publicKey: KeyObject
-  ): DiffieHellmanOptions = {
-    val obj = js.Dynamic.literal(
-      "privateKey" -> privateKey,
-      "publicKey"  -> publicKey
-    )
-    obj.asInstanceOf[DiffieHellmanOptions]
-  }
 }

--- a/app/nodejs-v10/src/test/scala/io/scalajs/nodejs/cluster/ClusterTest.scala
+++ b/app/nodejs-v10/src/test/scala/io/scalajs/nodejs/cluster/ClusterTest.scala
@@ -7,6 +7,25 @@ import scala.scalajs.js
 import org.scalatest.funspec.AnyFunSpec
 
 class ClusterTest extends AnyFunSpec {
+  describe("ClusterSettings") {
+    it("can be instantiated") {
+      val settings: ClusterSettings = ClusterSettings(
+        cwd = "/home/user",
+        exec = "ls",
+        execArgv = js.Array(),
+        args = js.Array(),
+        gid = 1,
+        uid = 2,
+        inspectPort = 3,
+        stdio = js.Array(),
+        windowsHide = false,
+        silent = true
+      )
+      assert(settings.silent === true)
+      assert(settings.gid === 1)
+    }
+  }
+
   describe("Cluster") {
     it("cluster should be master") {
       assert(Cluster.isMaster)

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -16,8 +16,10 @@ object Dependencies {
   val app = Def.setting(
     Seq(
       scalaReflect.value,
-      "org.scalatest"            %%% "scalatest" % scalatestVersion % "test",
-      "com.thoughtworks.enableIf" %% "enableif"  % "1.1.7"
+      "net.exoego"               %%% "scalajs-types-util" % "0.1.0",
+      "org.scalatest"            %%% "scalatest"          % scalatestVersion % "test",
+      "com.thoughtworks.enableIf" %% "enableif"           % "1.1.7"
     )
   )
+
 }


### PR DESCRIPTION
Preparation for #203 and #231 

`@Factory` macro from https://github.com/exoego/scalajs-util-types is handy because it eliminates tons of extra companion objects just for factory method.
