### PR TITLE
[BREAKING] Use Factory macro for optimization and maintainability

### DIFF
--- a/app/current/src/main/scala/io/scalajs/nodejs/Require.scala
+++ b/app/current/src/main/scala/io/scalajs/nodejs/Require.scala
@@ -1,5 +1,7 @@
 package io.scalajs.nodejs
 
+import _root_.net.exoego.scalajs.types.util.Factory
+
 import scala.scalajs.js
 import scala.scalajs.js.annotation.JSGlobal
 
@@ -23,6 +25,7 @@ trait RequireResolver extends js.Object {
   def paths(requiest: String): js.Array[String] = js.native
 }
 
-class ResolveOptions(
-    var paths: js.UndefOr[js.Array[String]] = js.undefined
-) extends js.Object
+@Factory
+trait ResolveOptions extends js.Object {
+  var paths: js.UndefOr[js.Array[String]] = js.undefined
+}

--- a/app/current/src/main/scala/io/scalajs/nodejs/child_process/ExecFileSyncOptions.scala
+++ b/app/current/src/main/scala/io/scalajs/nodejs/child_process/ExecFileSyncOptions.scala
@@ -1,6 +1,7 @@
 package io.scalajs.nodejs.child_process
 
 import io.scalajs.nodejs.{GID, UID}
+import net.exoego.scalajs.types.util.Factory
 
 import scala.scalajs.js
 import scala.scalajs.js.|
@@ -10,35 +11,60 @@ import scala.scalajs.js.|
   *
   * Note: Never pass unsanitized user input to this function. Any input containing shell meta-characters
   * may be used to trigger arbitrary command execution.
-  *
-  * @param cwd        Current working directory of the child process
-  * @param input      The value which will be passed as stdin to the spawned process.
-  *                   Supplying this value will override stdio[0].
-  * @param stdio      Child's stdio configuration. stderr by default will be output to the parent process' stderr unless stdio is specified.
-  *                   Default: 'pipe'.
-  * @param env        Environment key-value pairs
-  * @param encoding   (Default: 'utf8')
-  * @param shell      Shell to execute the command with (Default: '/bin/sh' on UNIX, 'cmd.exe' on Windows,
-  *                   The shell should understand the -c switch on UNIX or /d /s /c on Windows. On Windows, command line
-  *                   parsing should be compatible with cmd.exe.)
-  * @param timeout    (Default: 0)
-  * @param maxBuffer  largest amount of data (in bytes) allowed on stdout or stderr - if exceeded child process
-  *                   is killed (Default: 200*1024)
-  * @param killSignal (Default: 'SIGTERM')
-  * @param uid        Sets the user identity of the process. (See setuid(2).)
-  * @param gid        Sets the group identity of the process. (See setgid(2).)
-  * @param windowsHide Hide the subprocess console window that would normally be created on Windows systems. Default: `false`.
   */
-class ExecFileSyncOptions(var cwd: js.UndefOr[String] = js.undefined,
-                          var input: js.UndefOr[Input] = js.undefined,
-                          var stdio: js.UndefOr[StdIo] = js.undefined,
-                          var env: js.UndefOr[js.Object] = js.undefined,
-                          var encoding: js.UndefOr[String] = js.undefined,
-                          var shell: js.UndefOr[Boolean | String] = js.undefined,
-                          var timeout: js.UndefOr[Int] = js.undefined,
-                          var maxBuffer: js.UndefOr[Int] = js.undefined,
-                          var killSignal: js.UndefOr[KillSignal] = js.undefined,
-                          var uid: js.UndefOr[UID] = js.undefined,
-                          var gid: js.UndefOr[GID] = js.undefined,
-                          var windowsHide: js.UndefOr[Boolean] = js.undefined
-) extends js.Object
+@Factory
+trait ExecFileSyncOptions extends js.Object {
+
+  /** Current working directory of the child process
+    */
+  var cwd: js.UndefOr[String] = js.undefined
+
+  /** The value which will be passed as stdin to the spawned process.
+    *                   Supplying this value will override stdio[0].
+    */
+  var input: js.UndefOr[Input] = js.undefined
+
+  /** Child's stdio configuration. stderr by default will be output to the parent process' stderr unless stdio is specified.
+    * Default: 'pipe'.
+    */
+  var stdio: js.UndefOr[StdIo] = js.undefined
+
+  /** Environment key-value pairs
+    *
+   */
+  var env: js.UndefOr[js.Object] = js.undefined
+
+  /** (Default: 'utf8')
+    */
+  var encoding: js.UndefOr[String] = js.undefined
+
+  /** Shell to execute the command with (Default: '/bin/sh' on UNIX, 'cmd.exe' on Windows,
+    *  The shell should understand the -c switch on UNIX or /d /s /c on Windows. On Windows, command line parsing should be compatible with cmd.exe.)
+    */
+  var shell: js.UndefOr[Boolean | String] = js.undefined
+
+  /** (Default: 0)
+    */
+  var timeout: js.UndefOr[Int] = js.undefined
+
+  /** largest amount of data (in bytes) allowed on stdout or stderr - if exceeded child process is killed (Default: 200*1024)
+    */
+  var maxBuffer: js.UndefOr[Int] = js.undefined
+
+  /** (Default: 'SIGTERM')
+    */
+  var killSignal: js.UndefOr[KillSignal] = js.undefined
+
+  /** Sets the user identity of the process. (See setuid(2).)
+    */
+  var uid: js.UndefOr[UID] = js.undefined
+
+  /** Sets the group identity of the process. (See setgid(2).)
+    */
+  var gid: js.UndefOr[GID] = js.undefined
+
+  /** Hide the subprocess console window that would normally be created on Windows systems.
+    * Default: `false`.
+    */
+  var windowsHide: js.UndefOr[Boolean] = js.undefined
+}

--- a/app/current/src/main/scala/io/scalajs/nodejs/child_process/ExecOptions.scala
+++ b/app/current/src/main/scala/io/scalajs/nodejs/child_process/ExecOptions.scala
@@ -1,6 +1,8 @@
 package io.scalajs.nodejs
 package child_process
 
+import _root_.net.exoego.scalajs.types.util.Factory
+
 import scala.scalajs.js
 import scala.scalajs.js.|
 
@@ -9,31 +11,56 @@ import scala.scalajs.js.|
   *
   * Note: Never pass unsanitized user input to this function. Any input containing shell meta-characters
   * may be used to trigger arbitrary command execution.
-  * @param cwd        Current working directory of the child process
-  * @param env        Environment key-value pairs
-  * @param encoding   (Default: 'utf8')
-  * @param shell      Shell to execute the command with (Default: '/bin/sh' on UNIX, 'cmd.exe' on Windows,
-  *                   The shell should understand the -c switch on UNIX or /d /s /c on Windows. On Windows, command line
-  *                   parsing should be compatible with cmd.exe.)
-  * @param timeout    (Default: 0)
-  * @param maxBuffer  largest amount of data (in bytes) allowed on stdout or stderr - if exceeded child process
-  *                   is killed (Default: 200*1024)
-  * @param killSignal (Default: 'SIGTERM')
-  * @param uid        Sets the user identity of the process. (See setuid(2).)
-  * @param gid        Sets the group identity of the process. (See setgid(2).)
-  * @param windowsHide Hide the subprocess console window that would normally be created on Windows systems. Default: `false`.
-  * @param windowsVerbatimArguments No quoting or escaping of arguments is done on Windows.
-  *                                 Ignored on Unix. This is set to true automatically when shell is specified and is CMD. Default: false.
   */
-class ExecOptions(var cwd: js.UndefOr[String] = js.undefined,
-                  var env: js.UndefOr[js.Object] = js.undefined,
-                  var encoding: js.UndefOr[String] = js.undefined,
-                  var shell: js.UndefOr[Boolean | String] = js.undefined,
-                  var timeout: js.UndefOr[Int] = js.undefined,
-                  var maxBuffer: js.UndefOr[Int] = js.undefined,
-                  var killSignal: js.UndefOr[KillSignal] = js.undefined,
-                  var uid: js.UndefOr[UID] = js.undefined,
-                  var gid: js.UndefOr[GID] = js.undefined,
-                  var windowsHide: js.UndefOr[Boolean] = js.undefined,
-                  var windowsVerbatimArguments: js.UndefOr[Boolean] = js.undefined
-) extends js.Object
+@Factory
+trait ExecOptions extends js.Object {
+
+  /** Current working directory of the child process
+    */
+  var cwd: js.UndefOr[String] = js.undefined
+
+  /** Environment key-value pairs
+    */
+  var env: js.UndefOr[js.Object] = js.undefined
+
+  /** (Default: 'utf8')
+    */
+  var encoding: js.UndefOr[String] = js.undefined
+
+  /** Shell to execute the command with (Default: '/bin/sh' on UNIX, 'cmd.exe' on Windows,
+    * The shell should understand the -c switch on UNIX or /d /s /c on Windows. On Windows, command line
+    * parsing should be compatible with cmd.exe.)
+    */
+  var shell: js.UndefOr[Boolean | String] = js.undefined
+
+  /** (Default: 0)
+    */
+  var timeout: js.UndefOr[Int] = js.undefined
+
+  /** largest amount of data (in bytes) allowed on stdout or stderr - if exceeded child process
+    * is killed (Default: 200*1024)
+    */
+  var maxBuffer: js.UndefOr[Int] = js.undefined
+
+  /** (Default: 'SIGTERM')
+    */
+  var killSignal: js.UndefOr[KillSignal] = js.undefined
+
+  /** Sets the user identity of the process. (See setuid(2).)
+    */
+  var uid: js.UndefOr[UID] = js.undefined
+
+  /** Sets the group identity of the process. (See setgid(2).)
+    */
+  var gid: js.UndefOr[GID] = js.undefined
+
+  /** Hide the subprocess console window that would normally be created on Windows systems.
+    * Default: `false`.
+    */
+  var windowsHide: js.UndefOr[Boolean] = js.undefined
+
+  /** No quoting or escaping of arguments is done on Windows.
+    * Ignored on Unix. This is set to true automatically when shell is specified and is CMD. Default: false.
+    */
+  var windowsVerbatimArguments: js.UndefOr[Boolean] = js.undefined
+}

--- a/app/current/src/main/scala/io/scalajs/nodejs/child_process/ForkOptions.scala
+++ b/app/current/src/main/scala/io/scalajs/nodejs/child_process/ForkOptions.scala
@@ -4,36 +4,47 @@ package child_process
 import scala.scalajs.js
 import scala.scalajs.js.|
 
-/**
-  * Fork Options
-  * @param cwd      Current working directory of the child process
-  * @param detached Prepare child to run independently of its parent process
-  *                 Specific behavior depends on the platform (see options.detached).
-  * @param env      Environment key-value pairs
-  * @param execPath Executable used to create the child process
-  * @param execArgv List of string arguments passed to the executable (Default: process.execArgv)
-  * @param serialization
-  *                  From Node.js v13.2.0, v12.16.0.
-  *                  Specify the kind of serialization used for sending messages between processes.
-  *                  Possible values are 'json' and 'advanced'. See Advanced Serialization for more details.
-  *                  Default: 'json'.
-  * @param silent   If true, stdin, stdout, and stderr of the child will be piped to the parent,
-  *                 otherwise they will be inherited from the parent, see the 'pipe' and 'inherit' options
-  *                 for child_process.spawn()'s stdio for more details (Default: false)
-  * @param stdio    Supports the array version of child_process.spawn()'s stdio option. When this
-  *                 option is provided, it overrides silent. The array must contain exactly one item with
-  *                 value 'ipc' or an error will be thrown. For instance [0, 1, 2, 'ipc'].
-  * @param uid      Sets the user identity of the process. (See setuid(2).)
-  * @param gid      Sets the group identity of the process. (See setgid(2).)
-  */
-class ForkOptions(var cwd: js.UndefOr[String] = js.undefined,
-                  var detached: js.UndefOr[Boolean] = js.undefined,
-                  var env: js.UndefOr[js.Object] = js.undefined,
-                  var execPath: js.UndefOr[String] = js.undefined,
-                  var execArgv: js.UndefOr[Array[String]] = js.undefined,
-                  var serialization: js.UndefOr[String] = js.undefined,
-                  var silent: js.UndefOr[Boolean] = js.undefined,
-                  var stdio: js.UndefOr[String | Array[String]] = js.undefined,
-                  var uid: js.UndefOr[UID] = js.undefined,
-                  var gid: js.UndefOr[GID] = js.undefined
-) extends js.Object
+trait ForkOptions extends js.Object {
+
+  /** Current working directory of the child process */
+  var cwd: js.UndefOr[String] = js.undefined
+
+  /** Prepare child to run independently of its parent process
+    * Specific behavior depends on the platform (see options.detached).
+    */
+  var detached: js.UndefOr[Boolean] = js.undefined
+
+  /** Environment key-value pairs  */
+  var env: js.UndefOr[js.Object] = js.undefined
+
+  /** Executable used to create the child process */
+  var execPath: js.UndefOr[String] = js.undefined
+
+  /** List of string arguments passed to the executable (Default: process.execArgv)  */
+  var execArgv: js.UndefOr[Array[String]] = js.undefined
+
+  /** From Node.js v13.2.0, v12.16.0.
+    * Specify the kind of serialization used for sending messages between processes.
+    * Possible values are 'json' and 'advanced'. See Advanced Serialization for more details.
+    * Default: 'json'.
+    */
+  var serialization: js.UndefOr[String] = js.undefined
+
+  /** If true, stdin, stdout, and stderr of the child will be piped to the parent,
+    * otherwise they will be inherited from the parent, see the 'pipe' and 'inherit' options
+    * for child_process.spawn()'s stdio for more details (Default: false)
+    */
+  var silent: js.UndefOr[Boolean] = js.undefined
+
+  /** Supports the array version of child_process.spawn()'s stdio option. When this
+    * option is provided, it overrides silent. The array must contain exactly one item with
+    * value 'ipc' or an error will be thrown. For instance [0, 1, 2, 'ipc'].
+    */
+  var stdio: js.UndefOr[String | Array[String]] = js.undefined
+
+  /** Sets the user identity of the process. (See setuid(2).)  */
+  var uid: js.UndefOr[UID] = js.undefined
+
+  /** Sets the group identity of the process. (See setgid(2).) */
+  var gid: js.UndefOr[GID] = js.undefined
+}

--- a/app/current/src/main/scala/io/scalajs/nodejs/child_process/SendOptions.scala
+++ b/app/current/src/main/scala/io/scalajs/nodejs/child_process/SendOptions.scala
@@ -1,7 +1,10 @@
 package io.scalajs.nodejs.child_process
 
+import net.exoego.scalajs.types.util.Factory
+
 import scala.scalajs.js
 
-class SendOptions(
-    var keepOpen: js.UndefOr[Boolean] = js.undefined
-) extends js.Object {}
+@Factory
+trait SendOptions extends js.Object {
+  var keepOpen: js.UndefOr[Boolean] = js.undefined
+}

--- a/app/current/src/main/scala/io/scalajs/nodejs/child_process/SpawnOptions.scala
+++ b/app/current/src/main/scala/io/scalajs/nodejs/child_process/SpawnOptions.scala
@@ -3,31 +3,46 @@ package io.scalajs.nodejs.child_process
 import scala.scalajs.js
 import scala.scalajs.js.|
 
-/**
-  * Spawn Options
-  *
-  * @param cwd      Current working directory of the child process
-  * @param env      Environment key-value pairs
-  * @param argv0    Explicitly set the value of argv[0] sent to the child process.
-  *                 This will be set to command if not specified.
-  * @param stdio    Child's stdio configuration. (See options.stdio)
-  * @param detached Prepare child to run independently of its parent process.
-  *                 Specific behavior depends on the platform, see options.detached)
-  * @param uid      Sets the user identity of the process. (See setuid(2).)
-  * @param gid      Sets the group identity of the process. (See setgid(2).)
-  * @param shell    If true, runs command inside of a shell.
-  *                 Uses '/bin/sh' on UNIX, and 'cmd.exe' on Windows. A different shell can be specified as a string.
-  *                 The shell should understand the -c switch on UNIX, or /d /s /c on Windows. Defaults to false (no shell).
-  */
-class SpawnOptions(
-    var cwd: js.UndefOr[String] = js.undefined,
-    var env: js.Any = js.undefined,
-    var argv0: js.UndefOr[String] = js.undefined,
-    var stdio: js.UndefOr[StdIo] = js.undefined,
-    var detached: js.UndefOr[Boolean] = js.undefined,
-    var uid: js.UndefOr[Int] = js.undefined,
-    var gid: js.UndefOr[Int] = js.undefined,
-    var shell: js.UndefOr[Boolean | String] = js.undefined,
-    var windowsVerbatimArguments: js.UndefOr[Boolean] = js.undefined,
-    var windowsHide: js.UndefOr[Boolean] = js.undefined
-) extends js.Object
+trait SpawnOptions extends js.Object {
+
+  /** Current working directory of the child process */
+  var cwd: js.UndefOr[String] = js.undefined
+
+  /** Environment key-value pairs */
+  var env: js.UndefOr[js.Object] = js.undefined
+
+  /** Explicitly set the value of argv[0] sent to the child process.
+    * This will be set to command if not specified.
+    */
+  var argv0: js.UndefOr[String] = js.undefined
+
+  /** Child's stdio configuration. (See options.stdio) */
+  var stdio: js.UndefOr[StdIo] = js.undefined
+
+  /** Prepare child to run independently of its parent process.
+    * Specific behavior depends on the platform, see options.detached)
+    */
+  var detached: js.UndefOr[Boolean] = js.undefined
+
+  /**  Sets the user identity of the process. (See setuid(2).) */
+  var uid: js.UndefOr[Int] = js.undefined
+
+  /** Sets the group identity of the process. (See setgid(2).)  */
+  var gid: js.UndefOr[Int] = js.undefined
+
+  /** If true, runs command inside of a shell.
+    * Uses '/bin/sh' on UNIX, and 'cmd.exe' on Windows. A different shell can be specified as a string.
+    * The shell should understand the -c switch on UNIX, or /d /s /c on Windows. Defaults to false (no shell).
+    */
+  var shell: js.UndefOr[Boolean | String] = js.undefined
+
+  /** No quoting or escaping of arguments is done on Windows.
+    * Ignored on Unix. This is set to true automatically when shell is specified and is CMD. Default: false.
+    */
+  var windowsVerbatimArguments: js.UndefOr[Boolean] = js.undefined
+
+  /** Hide the subprocess console window that would normally be created on Windows systems.
+    * Default: `false`.
+    */
+  var windowsHide: js.UndefOr[Boolean] = js.undefined
+}

--- a/app/current/src/main/scala/io/scalajs/nodejs/child_process/SpawnSyncOptions.scala
+++ b/app/current/src/main/scala/io/scalajs/nodejs/child_process/SpawnSyncOptions.scala
@@ -10,41 +10,63 @@ import scala.scalajs.js.|
   *
   * Note: Never pass unsanitized user input to this function. Any input containing shell meta-characters
   * may be used to trigger arbitrary command execution.
-  *
-  * @param cwd        Current working directory of the child process
-  * @param input      The value which will be passed as stdin to the spawned process.
-  *                   Supplying this value will override stdio[0].
-  * @param argv0    Explicitly set the value of argv[0] sent to the child process.
-  *                 This will be set to command if not specified.
-  * @param stdio      Child's stdio configuration. stderr by default will be output to the parent process' stderr unless stdio is specified.
-  *                   Default: 'pipe'.
-  * @param env        Environment key-value pairs
-  * @param encoding   (Default: 'utf8')
-  * @param shell      Shell to execute the command with (Default: '/bin/sh' on UNIX, 'cmd.exe' on Windows,
-  *                   The shell should understand the -c switch on UNIX or /d /s /c on Windows. On Windows, command line
-  *                   parsing should be compatible with cmd.exe.)
-  * @param timeout    (Default: 0)
-  * @param maxBuffer  largest amount of data (in bytes) allowed on stdout or stderr - if exceeded child process
-  *                   is killed (Default: 200*1024)
-  * @param killSignal (Default: 'SIGTERM')
-  * @param uid        Sets the user identity of the process. (See setuid(2).)
-  * @param gid        Sets the group identity of the process. (See setgid(2).)
-  * @param windowsHide Hide the subprocess console window that would normally be created on Windows systems. Default: `false`.
-  * @param windowsVerbatimArguments No quoting or escaping of arguments is done on Windows.
-  *                                 Ignored on Unix. This is set to true automatically when shell is specified and is CMD. Default: false.
   */
-class SpawnSyncOptions(var cwd: js.UndefOr[String] = js.undefined,
-                       var input: js.UndefOr[Input] = js.undefined,
-                       var argv0: js.UndefOr[String] = js.undefined,
-                       var stdio: js.UndefOr[StdIo] = js.undefined,
-                       var env: js.UndefOr[js.Object] = js.undefined,
-                       var encoding: js.UndefOr[String] = js.undefined,
-                       var shell: js.UndefOr[Boolean | String] = js.undefined,
-                       var timeout: js.UndefOr[Int] = js.undefined,
-                       var maxBuffer: js.UndefOr[Int] = js.undefined,
-                       var killSignal: js.UndefOr[KillSignal] = js.undefined,
-                       var uid: js.UndefOr[UID] = js.undefined,
-                       var gid: js.UndefOr[GID] = js.undefined,
-                       var windowsHide: js.UndefOr[Boolean] = js.undefined,
-                       var windowsVerbatimArguments: js.UndefOr[Boolean] = js.undefined
-) extends js.Object
+trait SpawnSyncOptions extends js.Object {
+
+  /** Current working directory of the child process */
+  var cwd: js.UndefOr[String] = js.undefined
+
+  /** The value which will be passed as stdin to the spawned process.
+    * Supplying this value will override stdio[0].
+    */
+  var input: js.UndefOr[Input] = js.undefined
+
+  /** Explicitly set the value of argv[0] sent to the child process.
+    * This will be set to command if not specified.
+    */
+  var argv0: js.UndefOr[String] = js.undefined
+
+  /** Child's stdio configuration. stderr by default will be output to the parent process' stderr unless stdio is specified.
+    * Default: 'pipe'.
+    */
+  var stdio: js.UndefOr[StdIo] = js.undefined
+
+  /** Environment key-value pairs */
+  var env: js.UndefOr[js.Object] = js.undefined
+
+  /** (Default: 'utf8') */
+  var encoding: js.UndefOr[String] = js.undefined
+
+  /** Shell to execute the command with (Default: '/bin/sh' on UNIX, 'cmd.exe' on Windows,
+    * The shell should understand the -c switch on UNIX or /d /s /c on Windows. On Windows, command line
+    * parsing should be compatible with cmd.exe.)
+    */
+  var shell: js.UndefOr[Boolean | String] = js.undefined
+
+  /** (Default: 0) */
+  var timeout: js.UndefOr[Int] = js.undefined
+
+  /** largest amount of data (in bytes) allowed on stdout or stderr - if exceeded child process
+    * is killed (Default: 200*1024)
+    */
+  var maxBuffer: js.UndefOr[Int] = js.undefined
+
+  /** (Default: 'SIGTERM') */
+  var killSignal: js.UndefOr[KillSignal] = js.undefined
+
+  /** Sets the user identity of the process. (See setuid(2).) */
+  var uid: js.UndefOr[UID] = js.undefined
+
+  /** Sets the group identity of the process. (See setgid(2).) */
+  var gid: js.UndefOr[GID] = js.undefined
+
+  /** Hide the subprocess console window that would normally be created on Windows systems.
+    * Default: `false`.
+    */
+  var windowsHide: js.UndefOr[Boolean] = js.undefined
+
+  /** No quoting or escaping of arguments is done on Windows.
+    * Ignored on Unix. This is set to true automatically when shell is specified and is CMD. Default: false.
+    */
+  var windowsVerbatimArguments: js.UndefOr[Boolean] = js.undefined
+}

--- a/app/current/src/main/scala/io/scalajs/nodejs/child_process/SpawnSyncResult.scala
+++ b/app/current/src/main/scala/io/scalajs/nodejs/child_process/SpawnSyncResult.scala
@@ -1,14 +1,17 @@
 package io.scalajs.nodejs.child_process
 
+import net.exoego.scalajs.types.util.Factory
+
 import scala.scalajs.js
 import scala.scalajs.js.|
 
-class SpawnSyncResult(
-    val pid: Int,
-    val output: js.Array[Output],
-    val stdout: Output,
-    val stderr: Output,
-    val status: Int | Null,
-    val signal: String | Null,
-    val error: js.UndefOr[js.Error]
-) extends js.Object
+@Factory
+trait SpawnSyncResult {
+  var pid: Int
+  var output: js.Array[Output]
+  var stdout: Output
+  var stderr: Output
+  var status: Int | Null
+  var signal: String | Null
+  var error: js.UndefOr[js.Error] = js.undefined
+}

--- a/app/current/src/main/scala/io/scalajs/nodejs/console_module/ConsoleDirOptions.scala
+++ b/app/current/src/main/scala/io/scalajs/nodejs/console_module/ConsoleDirOptions.scala
@@ -1,17 +1,26 @@
 package io.scalajs.nodejs.console_module
 
+import net.exoego.scalajs.types.util.Factory
+
 import scala.scalajs.js
 
-/**
-  * Console Dir Options
-  *
-  * @param showHidden if true then the object's non-enumerable and symbol properties will be shown too. Defaults to `false`.
-  * @param depth      tells util.inspect() how many times to recurse while formatting the object. This is useful for
-  *                   inspecting large complicated objects. Defaults to `2`. To make it recurse indefinitely, pass null.
-  * @param colors     if true, then the output will be styled with ANSI color codes. Defaults to `false`. Colors are customizable;
-  *                   see customizing util.inspect() colors.
-  */
-class ConsoleDirOptions(var showHidden: js.UndefOr[Boolean] = js.undefined,
-                        var depth: js.UndefOr[Int] = js.undefined,
-                        var colors: js.UndefOr[Boolean] = js.undefined
-) extends js.Object
+@Factory
+trait ConsoleDirOptions extends js.Object {
+
+  /** if true then the object's non-enumerable and symbol properties will be shown too. Defaults to `false`.
+    */
+  var showHidden: js.UndefOr[Boolean] = js.undefined
+
+  /** tells util.inspect() how many times to recurse while formatting the object.
+    * This is useful for inspecting large complicated objects.
+    * Defaults to `2`.
+    * To make it recurse indefinitely, pass null.
+    */
+  var depth: js.UndefOr[Int] = js.undefined
+
+  /** if true, then the output will be styled with ANSI color codes.
+    * Defaults to `false`.
+    * Colors are customizable;see customizing util.inspect() colors.
+    */
+  var colors: js.UndefOr[Boolean] = js.undefined
+}

--- a/app/current/src/main/scala/io/scalajs/nodejs/console_module/ConsoleOptions.scala
+++ b/app/current/src/main/scala/io/scalajs/nodejs/console_module/ConsoleOptions.scala
@@ -2,29 +2,36 @@ package io.scalajs.nodejs.console_module
 
 import io.scalajs.nodejs.stream.IWritable
 import io.scalajs.nodejs.util.InspectOptions
+import net.exoego.scalajs.types.util.Factory
 
 import scala.scalajs.js
 import scala.scalajs.js.|
 
-/**
-  *
-  * @param stdout
-  * @param stderr
-  * @param ignoreErrors Ignore errors when writing to the underlying streams. Defaults to `true`.
-  * @param colorMode      Set color support for this `Console` instance.
-  *                       Setting to `true` enables coloring while inspecting values,
-  *                       setting to `'auto'` will make color support depend on the value of the `isTTY` property and the value returned by `getColorDepth()` on the respective stream.
-  *                       This option can not be used, if `inspectOptions.colors` is set as well. Defaults to `'auto'`.
-  * @param inspectOptions Specifies options that are passed along to [[io.scalajs.nodejs.util.Util.inspect()]].
-  *                       Node.js v11.7.0.
-  * @param groupIndentation Set group indentation. Default: 2.
-  *                       Node.js v14.2.0.
-  */
-class ConsoleOptions(
-    var stdout: IWritable,
-    var stderr: js.UndefOr[IWritable] = js.undefined,
-    var ignoreErrors: Boolean = true,
-    var colorMode: Boolean | String = "auto",
-    var inspectOptions: js.UndefOr[InspectOptions] = js.undefined,
-    var groupIndentation: js.UndefOr[Int] = js.undefined
-) extends js.Object
+@Factory
+trait ConsoleOptions extends js.Object {
+  var stdout: IWritable
+  var stderr: js.UndefOr[IWritable] = js.undefined
+
+  /** Ignore errors when writing to the underlying streams.
+    *  Defaults to `true`.
+    */
+  var ignoreErrors: js.UndefOr[Boolean] = js.undefined
+
+  /** Set color support for this `Console` instance.
+    * Setting to `true` enables coloring while inspecting values,
+    * setting to `'auto'` will make color support depend on the value of the `isTTY` property and the value returned by `getColorDepth()` on the respective stream.
+    * This option can not be used, if `inspectOptions.colors` is set as well.
+    * Defaults to `'auto'`.
+    */
+  var colorMode: js.UndefOr[Boolean | String] = js.undefined
+
+  /** Specifies options that are passed along to [[io.scalajs.nodejs.util.Util.inspect()]].
+    * Node.js v11.7.0.
+    */
+  var inspectOptions: js.UndefOr[InspectOptions] = js.undefined
+
+  /** Set group indentation. Default: 2.
+    * Node.js v14.2.0.
+    */
+  var groupIndentation: js.UndefOr[Int] = js.undefined
+}

--- a/app/current/src/main/scala/io/scalajs/nodejs/crypto/Cipher.scala
+++ b/app/current/src/main/scala/io/scalajs/nodejs/crypto/Cipher.scala
@@ -85,6 +85,7 @@ sealed trait Cipher extends Transform {
   def update(data: BufferLike): Buffer                                            = js.native
 }
 
+// TODO: Use Factory macro
 class SetAADOptions(transform: js.UndefOr[js.Function] = js.undefined,
                     flush: js.UndefOr[js.Function] = js.undefined,
                     var plaintextLength: js.UndefOr[Int] = js.undefined

--- a/app/current/src/main/scala/io/scalajs/nodejs/crypto/Crypto.scala
+++ b/app/current/src/main/scala/io/scalajs/nodejs/crypto/Crypto.scala
@@ -3,9 +3,9 @@ package io.scalajs.nodejs.crypto
 import com.thoughtworks.enableIf
 import io.scalajs.nodejs.buffer.Buffer
 import io.scalajs.nodejs.stream.{TransformOptions, WritableOptions}
+import net.exoego.scalajs.types.util.Factory
 
 import scala.scalajs.js
-
 import scala.scalajs.js.annotation.JSImport
 import scala.scalajs.js.|
 
@@ -385,37 +385,42 @@ object Constants extends js.Object {
   val defaultCipherList: String     = js.native
 }
 
-class CreatePrivateKeyOptions(
-    val key: String | Buffer,
-    var format: js.UndefOr[String] = js.undefined,
-    var `type`: js.UndefOr[String] = js.undefined,
-    var passphrase: js.UndefOr[String | Buffer] = js.undefined
-) extends js.Object
+@Factory
+trait CreatePrivateKeyOptions extends js.Object {
+  val key: String | Buffer
+  var format: js.UndefOr[String]              = js.undefined
+  var `type`: js.UndefOr[String]              = js.undefined
+  var passphrase: js.UndefOr[String | Buffer] = js.undefined
+}
 
-class CreatePublicKeyOptions(
-    val key: String | Buffer,
-    var format: js.UndefOr[String] = js.undefined,
-    var `type`: js.UndefOr[String] = js.undefined
-) extends js.Object
+@Factory
+trait CreatePublicKeyOptions extends js.Object {
+  val key: String | Buffer
 
-class GenerateKeyPairOptions(
-    val modulusLength: Int,
-    var publicExponent: js.UndefOr[Int] = js.undefined,
-    var divisorLength: js.UndefOr[Int] = js.undefined,
-    var namedCurve: js.UndefOr[String] = js.undefined,
-    var publicKeyEncoding: js.UndefOr[KeyObjectExportOptions] = js.undefined,
-    var privateKeyEncoding: js.UndefOr[KeyObjectExportOptions] = js.undefined
-) extends js.Object
+  var format: js.UndefOr[String] = js.undefined
+  var `type`: js.UndefOr[String] = js.undefined
+}
 
-class ScryptOptions(
-    var cost: js.UndefOr[Int] = js.undefined,
-    var blockSize: js.UndefOr[Int] = js.undefined,
-    var parallelization: js.UndefOr[Int] = js.undefined,
-    var N: js.UndefOr[Int] = js.undefined,
-    var r: js.UndefOr[Int] = js.undefined,
-    var p: js.UndefOr[Int] = js.undefined,
-    var maxmem: js.UndefOr[Int] = js.undefined
-) extends js.Object
+@Factory
+trait GenerateKeyPairOptions extends js.Object {
+  val modulusLength: Int
+  var publicExponent: js.UndefOr[Int]                        = js.undefined
+  var divisorLength: js.UndefOr[Int]                         = js.undefined
+  var namedCurve: js.UndefOr[String]                         = js.undefined
+  var publicKeyEncoding: js.UndefOr[KeyObjectExportOptions]  = js.undefined
+  var privateKeyEncoding: js.UndefOr[KeyObjectExportOptions] = js.undefined
+}
+
+@Factory
+trait ScryptOptions extends js.Object {
+  var cost: js.UndefOr[Int]            = js.undefined
+  var blockSize: js.UndefOr[Int]       = js.undefined
+  var parallelization: js.UndefOr[Int] = js.undefined
+  var N: js.UndefOr[Int]               = js.undefined
+  var r: js.UndefOr[Int]               = js.undefined
+  var p: js.UndefOr[Int]               = js.undefined
+  var maxmem: js.UndefOr[Int]          = js.undefined
+}
 
 @js.native
 trait KeyPair extends js.Object {

--- a/app/current/src/main/scala/io/scalajs/nodejs/crypto/Hash.scala
+++ b/app/current/src/main/scala/io/scalajs/nodejs/crypto/Hash.scala
@@ -72,6 +72,7 @@ sealed trait Hash extends Transform {
   def update(data: BufferLike): Hash                    = js.native
 }
 
+// TODO: Use Fatory macro
 class CreateHashOptions(transform: js.UndefOr[js.Function] = js.undefined,
                         flush: js.UndefOr[js.Function] = js.undefined,
                         var outputLength: js.UndefOr[Int] = js.undefined

--- a/app/current/src/main/scala/io/scalajs/nodejs/crypto/KeyObject.scala
+++ b/app/current/src/main/scala/io/scalajs/nodejs/crypto/KeyObject.scala
@@ -1,6 +1,7 @@
 package io.scalajs.nodejs.crypto
 
 import io.scalajs.nodejs.buffer.Buffer
+import net.exoego.scalajs.types.util.Factory
 
 import scala.scalajs.js
 import scala.scalajs.js.typedarray.{DataView, TypedArray}
@@ -31,34 +32,39 @@ sealed trait KeyObject extends js.Object {
   val `type`: String = js.native
 }
 
-class KeyObjectExportOptions(
-    var `type`: js.UndefOr[String] = js.undefined,
-    var format: js.UndefOr[String] = js.undefined,
-    var cipher: js.UndefOr[String] = js.undefined,
-    var passphrase: js.UndefOr[String | Buffer] = js.undefined
-) extends js.Object
+@Factory
+trait KeyObjectExportOptions extends js.Object {
+  var `type`: js.UndefOr[String]              = js.undefined
+  var format: js.UndefOr[String]              = js.undefined
+  var cipher: js.UndefOr[String]              = js.undefined
+  var passphrase: js.UndefOr[String | Buffer] = js.undefined
+}
 
-class PublicEncryptKeyObject(
-    var key: String | Buffer | KeyObject,
-    var oaepHash: String = "sha1",
-    var oaepLabel: js.UndefOr[Buffer | TypedArray[_, _] | DataView] = js.undefined,
-    var passphrase: js.UndefOr[String | Buffer] = js.undefined,
-    var padding: js.UndefOr[Int] = js.undefined
-) extends js.Object
+@Factory
+trait PublicEncryptKeyObject extends js.Object {
+  var key: String | Buffer | KeyObject
+  var oaepHash: js.UndefOr[String]                                = js.undefined
+  var oaepLabel: js.UndefOr[Buffer | TypedArray[_, _] | DataView] = js.undefined
+  var passphrase: js.UndefOr[String | Buffer]                     = js.undefined
+  var padding: js.UndefOr[Int]                                    = js.undefined
+}
 
-class PublicDecryptKeyObject(
-    var passphrase: js.UndefOr[String | Buffer] = js.undefined,
-    var padding: js.UndefOr[Int] = js.undefined
-) extends js.Object
+@Factory
+trait PublicDecryptKeyObject extends js.Object {
+  var passphrase: js.UndefOr[String | Buffer] = js.undefined
+  var padding: js.UndefOr[Int]                = js.undefined
+}
 
-class PrivateEncryptKeyObject(
-    var key: String | Buffer | KeyObject,
-    var passphrase: js.UndefOr[String | Buffer] = js.undefined,
-    var padding: js.UndefOr[Int] = js.undefined
-) extends js.Object
+@Factory
+trait PrivateEncryptKeyObject extends js.Object {
+  var key: String | Buffer | KeyObject
+  var passphrase: js.UndefOr[String | Buffer] = js.undefined
+  var padding: js.UndefOr[Int]                = js.undefined
+}
 
-class PrivateDecryptKeyObject(
-    var oaepHash: String = "sha1",
-    var oaepLabel: js.UndefOr[Buffer | TypedArray[_, _] | DataView] = js.undefined,
-    var padding: js.UndefOr[Int] = js.undefined
-) extends js.Object
+@Factory
+trait PrivateDecryptKeyObject extends js.Object {
+  var oaepHash: js.UndefOr[String]                                = js.undefined
+  var oaepLabel: js.UndefOr[Buffer | TypedArray[_, _] | DataView] = js.undefined
+  var padding: js.UndefOr[Int]                                    = js.undefined
+}

--- a/app/current/src/main/scala/io/scalajs/nodejs/dgram/Dgram.scala
+++ b/app/current/src/main/scala/io/scalajs/nodejs/dgram/Dgram.scala
@@ -1,5 +1,7 @@
 package io.scalajs.nodejs.dgram
 
+import net.exoego.scalajs.types.util.Factory
+
 import scala.scalajs.js
 import scala.scalajs.js.annotation.JSImport
 
@@ -10,14 +12,16 @@ trait Dgram extends js.Object {
   def createSocket(`type`: String): Socket                                            = js.native
 }
 
-class SocketOptions(
-    var `type`: String,
-    var reuseAddr: js.UndefOr[Boolean] = js.undefined,
-    var ipv6Only: js.UndefOr[Boolean] = js.undefined,
-    var recvBufferSize: js.UndefOr[Int] = js.undefined,
-    var sendBufferSize: js.UndefOr[Int] = js.undefined,
-    var lookup: js.UndefOr[js.Function1[String, Any]] = js.undefined
-) extends js.Object
+@Factory
+trait SocketOptions extends js.Object {
+  var `type`: String
+
+  var reuseAddr: js.UndefOr[Boolean]                = js.undefined
+  var ipv6Only: js.UndefOr[Boolean]                 = js.undefined
+  var recvBufferSize: js.UndefOr[Int]               = js.undefined
+  var sendBufferSize: js.UndefOr[Int]               = js.undefined
+  var lookup: js.UndefOr[js.Function1[String, Any]] = js.undefined
+}
 
 @js.native
 @JSImport("dgram", JSImport.Namespace)

--- a/app/current/src/main/scala/io/scalajs/nodejs/dgram/Socket.scala
+++ b/app/current/src/main/scala/io/scalajs/nodejs/dgram/Socket.scala
@@ -4,6 +4,7 @@ package dgram
 import com.thoughtworks.enableIf
 import io.scalajs.nodejs.events.IEventEmitter
 import io.scalajs.nodejs.net.Address
+import _root_.net.exoego.scalajs.types.util.Factory
 
 import scala.scalajs.js
 import scala.scalajs.js.annotation.JSImport
@@ -118,12 +119,13 @@ class Socket private[this] () extends IEventEmitter {
   def unref(): this.type                                      = js.native
 }
 
-class BindOptions(
-    var port: js.UndefOr[Int] = js.undefined,
-    var address: js.UndefOr[String] = js.undefined,
-    var exclusive: js.UndefOr[Boolean] = js.undefined,
-    var fd: js.UndefOr[Int] = js.undefined
-) extends js.Object {}
+@Factory
+trait BindOptions extends js.Object {
+  var port: js.UndefOr[Int]          = js.undefined
+  var address: js.UndefOr[String]    = js.undefined
+  var exclusive: js.UndefOr[Boolean] = js.undefined
+  var fd: js.UndefOr[Int]            = js.undefined
+}
 
 @js.native
 trait RemoteAddress extends js.Object {

--- a/app/current/src/main/scala/io/scalajs/nodejs/dns/DnsOptions.scala
+++ b/app/current/src/main/scala/io/scalajs/nodejs/dns/DnsOptions.scala
@@ -1,9 +1,13 @@
 package io.scalajs.nodejs.dns
 
+import net.exoego.scalajs.types.util.Factory
+
 import scala.scalajs.js
 
-class DnsOptions(var family: js.UndefOr[Int] = js.undefined,
-                 var hints: js.UndefOr[Int] = js.undefined,
-                 var all: js.UndefOr[Boolean] = js.undefined,
-                 var verbatim: js.UndefOr[Boolean] = js.undefined
-) extends js.Object
+@Factory
+trait DnsOptions extends js.Object {
+  var family: js.UndefOr[Int]       = js.undefined
+  var hints: js.UndefOr[Int]        = js.undefined
+  var all: js.UndefOr[Boolean]      = js.undefined
+  var verbatim: js.UndefOr[Boolean] = js.undefined
+}

--- a/app/current/src/main/scala/io/scalajs/nodejs/dns/TtlOptions.scala
+++ b/app/current/src/main/scala/io/scalajs/nodejs/dns/TtlOptions.scala
@@ -1,7 +1,10 @@
 package io.scalajs.nodejs.dns
 
+import net.exoego.scalajs.types.util.Factory
+
 import scala.scalajs.js
 
-class TtlOptions(
-    var ttl: js.UndefOr[Boolean] = js.undefined
-) extends js.Object {}
+@Factory
+trait TtlOptions extends js.Object {
+  var ttl: js.UndefOr[Boolean] = js.undefined
+}

--- a/app/current/src/main/scala/io/scalajs/nodejs/fs/FSWatcher.scala
+++ b/app/current/src/main/scala/io/scalajs/nodejs/fs/FSWatcher.scala
@@ -1,6 +1,7 @@
 package io.scalajs.nodejs
 package fs
 
+import _root_.net.exoego.scalajs.types.util.Factory
 import io.scalajs.nodejs.events.IEventEmitter
 
 import scala.scalajs.js
@@ -19,14 +20,17 @@ trait FSWatcher extends IEventEmitter {
   def close(): Unit = js.native
 }
 
-/**
-  * FS Watcher Options
-  * @param encoding   Specifies the character encoding to be used for the filename passed to the listener (default: "utf8")
-  * @param persistent Indicates whether the process should continue to run as long as files are being watched (default: true)
-  * @param recursive  Indicates whether all subdirectories should be watched, or only the current directory.
-  *                   The applies when a directory is specified, and only on supported platforms (See Caveats) (default: false)
-  */
-class FSWatcherOptions(var encoding: js.UndefOr[String] = js.undefined,
-                       var persistent: js.UndefOr[Boolean] = js.undefined,
-                       var recursive: js.UndefOr[Boolean] = js.undefined
-) extends js.Object
+@Factory
+trait FSWatcherOptions extends js.Object {
+
+  /** Specifies the character encoding to be used for the filename passed to the listener (default: "utf8") */
+  var encoding: js.UndefOr[String] = js.undefined
+
+  /** Indicates whether the process should continue to run as long as files are being watched (default: true) */
+  var persistent: js.UndefOr[Boolean] = js.undefined
+
+  /** Indicates whether all subdirectories should be watched, or only the current directory.
+    * The applies when a directory is specified, and only on supported platforms (See Caveats) (default: false)
+    */
+  var recursive: js.UndefOr[Boolean] = js.undefined
+}

--- a/app/current/src/main/scala/io/scalajs/nodejs/fs/Fs.scala
+++ b/app/current/src/main/scala/io/scalajs/nodejs/fs/Fs.scala
@@ -3,6 +3,7 @@ package fs
 
 import com.thoughtworks.{enableIf, enableMembersIf}
 import io.scalajs.nodejs.buffer.Buffer
+import _root_.net.exoego.scalajs.types.util.Factory
 
 import scala.scalajs.js
 import scala.scalajs.js.annotation.JSImport
@@ -1251,66 +1252,82 @@ trait BufferIOResult[T] extends js.Object {
   val buffer: T      = js.native
 }
 
-/**
-  * File Append Options
-  */
-class FileAppendOptions(var encoding: js.UndefOr[String] = js.undefined,
-                        var mode: js.UndefOr[FileMode] = js.undefined,
-                        var flag: js.UndefOr[String] = js.undefined
-) extends js.Object
+@Factory
+trait FileAppendOptions extends js.Object {
+  var encoding: js.UndefOr[String] = js.undefined
+  var mode: js.UndefOr[FileMode]   = js.undefined
+  var flag: js.UndefOr[String]     = js.undefined
+}
 
-/**
-  * File Encoding Options
-  */
-class FileEncodingOptions(var encoding: js.UndefOr[String] = js.undefined) extends js.Object
+@Factory
+trait FileEncodingOptions {
+  var encoding: js.UndefOr[String] = js.undefined
+}
 
-class ReaddirOptions(var encoding: js.UndefOr[String] = js.undefined,
-                     var withFileTypes: js.UndefOr[Boolean] = js.undefined
-) extends js.Object
+@Factory
+trait ReaddirOptions extends js.Object {
+  var encoding: js.UndefOr[String]       = js.undefined
+  var withFileTypes: js.UndefOr[Boolean] = js.undefined
+}
 
-class OpendirOptions(var encoding: js.UndefOr[String] = js.undefined, var bufferSize: js.UndefOr[Double] = js.undefined)
-    extends js.Object
+@Factory
+trait OpendirOptions extends js.Object {
+  var encoding: js.UndefOr[String]   = js.undefined
+  var bufferSize: js.UndefOr[Double] = js.undefined
+}
 
-class ReadFileOptions(var flag: js.UndefOr[String] = js.undefined) extends js.Object
+@Factory
+trait ReadFileOptions extends js.Object {
+  var flag: js.UndefOr[String] = js.undefined
+}
 
-class FileInputOptions(var flags: js.UndefOr[String] = js.undefined,
-                       var encoding: js.UndefOr[String] = js.undefined,
-                       var fd: js.UndefOr[FileDescriptor] = js.undefined,
-                       var mode: js.UndefOr[FileMode] = js.undefined,
-                       var autoClose: js.UndefOr[Boolean] = js.undefined,
-                       var emitClose: js.UndefOr[Boolean] = js.undefined,
-                       var start: js.UndefOr[Int] = js.undefined,
-                       var end: js.UndefOr[Int] = js.undefined,
-                       var highWaterMark: js.UndefOr[Int] = js.undefined
-) extends js.Object
+@Factory
+trait FileInputOptions extends js.Object {
+  var flags: js.UndefOr[String]      = js.undefined
+  var encoding: js.UndefOr[String]   = js.undefined
+  var fd: js.UndefOr[FileDescriptor] = js.undefined
+  var mode: js.UndefOr[FileMode]     = js.undefined
+  var autoClose: js.UndefOr[Boolean] = js.undefined
+  var emitClose: js.UndefOr[Boolean] = js.undefined
+  var start: js.UndefOr[Int]         = js.undefined
+  var end: js.UndefOr[Int]           = js.undefined
+  var highWaterMark: js.UndefOr[Int] = js.undefined
+}
 
-class FileOutputOptions(var flags: js.UndefOr[String] = js.undefined,
-                        var defaultEncoding: js.UndefOr[String] = js.undefined,
-                        var fd: js.UndefOr[FileDescriptor] = js.undefined,
-                        var mode: js.UndefOr[FileMode] = js.undefined,
-                        var autoClose: js.UndefOr[Boolean] = js.undefined,
-                        var emitClose: js.UndefOr[Boolean] = js.undefined,
-                        var start: js.UndefOr[Int] = js.undefined
-) extends js.Object
+@Factory
+trait FileOutputOptions extends js.Object {
+  var flags: js.UndefOr[String]           = js.undefined
+  var defaultEncoding: js.UndefOr[String] = js.undefined
+  var fd: js.UndefOr[FileDescriptor]      = js.undefined
+  var mode: js.UndefOr[FileMode]          = js.undefined
+  var autoClose: js.UndefOr[Boolean]      = js.undefined
+  var emitClose: js.UndefOr[Boolean]      = js.undefined
+  var start: js.UndefOr[Int]              = js.undefined
+}
 
-/**
-  * File Watcher Options
-  * @param persistent <Boolean>
-  * @param interval   <Integer>
-  */
-class FileWatcherOptions(var persistent: js.UndefOr[Boolean] = js.undefined,
-                         var interval: js.UndefOr[Int] = js.undefined
-) extends js.Object
+@Factory
+trait FileWatcherOptions extends js.Object {
+  var persistent: js.UndefOr[Boolean] = js.undefined
+  var interval: js.UndefOr[Int]       = js.undefined
+}
 
-class StatOptions(var bigint: js.UndefOr[Boolean] = js.undefined) extends js.Object
+@Factory
+trait StatOptions {
+  var bigint: js.UndefOr[Boolean] = js.undefined
+}
 
-class MkdirOptions(var recursive: js.UndefOr[Boolean] = js.undefined, var mode: js.UndefOr[FileMode] = js.undefined)
-    extends js.Object
+@Factory
+trait MkdirOptions extends js.Object {
+  var recursive: js.UndefOr[Boolean] = js.undefined
+  var mode: js.UndefOr[FileMode]     = js.undefined
+}
 
-class RmdirOptions(var emfileWait: js.UndefOr[Int] = 1000,
-                   var maxBusyTries: js.UndefOr[Int] = 3,
-                   var recursive: js.UndefOr[Boolean] = js.undefined
-) extends js.Object
+@Factory
+trait RmdirOptions extends js.Object {
+  var emfileWait: js.UndefOr[Int]    = js.undefined
+  var maxBusyTries: js.UndefOr[Int]  = js.undefined
+  var recursive: js.UndefOr[Boolean] = js.undefined
+}
 
 @js.native
 trait RealpathObject extends js.Object {

--- a/app/current/src/main/scala/io/scalajs/nodejs/fs/package.scala
+++ b/app/current/src/main/scala/io/scalajs/nodejs/fs/package.scala
@@ -157,13 +157,13 @@ package object fs {
 
     @inline
     def mkdirRecursiveFuture(path: Path): Future[Unit] = {
-      val recursiveEnabled = new MkdirOptions(recursive = true)
+      val recursiveEnabled = MkdirOptions(recursive = true)
       promiseWithError0[FileIOError](instance.mkdir(path, recursiveEnabled, _))
     }
 
     @inline
     def mkdirRecursiveFuture(path: Path, options: MkdirOptions): Future[Unit] = {
-      val recursiveEnabled = new MkdirOptions(
+      val recursiveEnabled = MkdirOptions(
         recursive = true,
         mode = options.mode
       )
@@ -239,7 +239,7 @@ package object fs {
       val callback: FsCallback1[js.Array[Buffer]] => Unit = { callback =>
         instance.readdir(
           path,
-          new FileEncodingOptions(encoding = "buffer"),
+          FileEncodingOptions(encoding = "buffer"),
           callback.asInstanceOf[FsCallback1[ReaddirArrays]]
         )
       }
@@ -251,7 +251,7 @@ package object fs {
       val callback: FsCallback1[js.Array[Dirent]] => Unit = { callback =>
         instance.readdir(
           path,
-          new ReaddirOptions(withFileTypes = true),
+          ReaddirOptions(withFileTypes = true),
           callback.asInstanceOf[FsCallback1[ReaddirArrays2]]
         )
       }
@@ -325,14 +325,14 @@ package object fs {
     @inline
     def rmdirRecursiveFuture(path: Path, options: RmdirOptions): Future[Unit] = {
       val recursiveEnabled =
-        new RmdirOptions(recursive = true, maxBusyTries = options.maxBusyTries, emfileWait = options.emfileWait)
+        RmdirOptions(recursive = true, maxBusyTries = options.maxBusyTries, emfileWait = options.emfileWait)
       promiseWithError0[FileIOError](instance.rmdir(path, recursiveEnabled, _))
     }
 
     @enableIf(io.scalajs.nodejs.internal.CompilerSwitches.gteNodeJs12)
     @inline
     def rmdirRecursiveFuture(path: Path): Future[Unit] = {
-      promiseWithError0[FileIOError](instance.rmdir(path, new RmdirOptions(recursive = true), _))
+      promiseWithError0[FileIOError](instance.rmdir(path, RmdirOptions(recursive = true), _))
     }
 
     @inline

--- a/app/current/src/main/scala/io/scalajs/nodejs/http/AgentOptions.scala
+++ b/app/current/src/main/scala/io/scalajs/nodejs/http/AgentOptions.scala
@@ -1,11 +1,14 @@
 package io.scalajs.nodejs.http
 
+import net.exoego.scalajs.types.util.Factory
+
 import scala.scalajs.js
 
-class AgentOptions(
-    var keepAlive: js.UndefOr[Boolean] = js.undefined,
-    var keepAliveMsecs: js.UndefOr[Int] = js.undefined,
-    var maxSockets: js.UndefOr[Double] = js.undefined,
-    var maxFreeSockets: js.UndefOr[Int] = js.undefined,
-    var timeout: js.UndefOr[Int] = js.undefined
-) extends js.Object
+@Factory
+trait AgentOptions extends js.Object {
+  var keepAlive: js.UndefOr[Boolean]  = js.undefined
+  var keepAliveMsecs: js.UndefOr[Int] = js.undefined
+  var maxSockets: js.UndefOr[Double]  = js.undefined
+  var maxFreeSockets: js.UndefOr[Int] = js.undefined
+  var timeout: js.UndefOr[Int]        = js.undefined
+}

--- a/app/current/src/main/scala/io/scalajs/nodejs/http/ConnectionOptions.scala
+++ b/app/current/src/main/scala/io/scalajs/nodejs/http/ConnectionOptions.scala
@@ -1,29 +1,34 @@
 package io.scalajs.nodejs.http
 
+import net.exoego.scalajs.types.util.Factory
+
 import scala.scalajs.js
 import scala.scalajs.js.typedarray.Uint8Array
 import scala.scalajs.js.|
 
-class ConnectionOptions(
-    // for socket.connect(option)
-    var port: Int,
-    var host: js.UndefOr[String] = js.undefined,
-    var localAddress: js.UndefOr[String] = js.undefined,
-    var localPort: js.UndefOr[Int] = js.undefined,
-    var family: js.UndefOr[Int] = js.undefined,
-    var hints: js.UndefOr[Int] = js.undefined,
-    var lookup: js.UndefOr[js.Function1[String, Any]] = js.undefined,
-    var onread: js.UndefOr[OnreadObject] = js.undefined,
-    // for IPC connections
-    var path: js.UndefOr[String] = js.undefined,
-    // for new Socket(option)
-    var fd: js.UndefOr[Int] = js.undefined,
-    var allowHalfOpen: js.UndefOr[Boolean] = js.undefined,
-    var readable: js.UndefOr[Boolean] = js.undefined,
-    var writable: js.UndefOr[Int] = js.undefined
-) extends js.Object
+@Factory
+trait ConnectionOptions extends js.Object {
+  // for socket.connect(option)
+  var port: Int
+  var host: js.UndefOr[String]                      = js.undefined
+  var localAddress: js.UndefOr[String]              = js.undefined
+  var localPort: js.UndefOr[Int]                    = js.undefined
+  var family: js.UndefOr[Int]                       = js.undefined
+  var hints: js.UndefOr[Int]                        = js.undefined
+  var lookup: js.UndefOr[js.Function1[String, Any]] = js.undefined
+  var onread: js.UndefOr[OnreadObject]              = js.undefined
 
-class OnreadObject(
-    var buffer: Uint8Array | js.Function0[Uint8Array],
-    var callback: js.Function2[Int, Uint8Array, Boolean]
-) extends js.Object
+  // for IPC connections
+  var path: js.UndefOr[String] = js.undefined
+
+  // for new Socket(option)
+  var fd: js.UndefOr[Int]                = js.undefined
+  var allowHalfOpen: js.UndefOr[Boolean] = js.undefined
+  var readable: js.UndefOr[Boolean]      = js.undefined
+  var writable: js.UndefOr[Int]          = js.undefined
+}
+@Factory
+trait OnreadObject extends js.Object {
+  var buffer: Uint8Array | js.Function0[Uint8Array]
+  var callback: js.Function2[Int, Uint8Array, Boolean]
+}

--- a/app/current/src/main/scala/io/scalajs/nodejs/http/GetNameOptions.scala
+++ b/app/current/src/main/scala/io/scalajs/nodejs/http/GetNameOptions.scala
@@ -1,10 +1,13 @@
 package io.scalajs.nodejs.http
 
+import net.exoego.scalajs.types.util.Factory
+
 import scala.scalajs.js
 
-class GetNameOptions(
-    var host: String,
-    var port: js.UndefOr[Int] = js.undefined,
-    var localAddress: js.UndefOr[String] = js.undefined,
-    var family: js.UndefOr[Int] = js.undefined
-) extends js.Object
+@Factory
+trait GetNameOptions extends js.Object {
+  var host: String
+  var port: js.UndefOr[Int]            = js.undefined
+  var localAddress: js.UndefOr[String] = js.undefined
+  var family: js.UndefOr[Int]          = js.undefined
+}

--- a/app/current/src/main/scala/io/scalajs/nodejs/http/RequestOptions.scala
+++ b/app/current/src/main/scala/io/scalajs/nodejs/http/RequestOptions.scala
@@ -2,41 +2,43 @@ package io.scalajs.nodejs.http
 
 import io.scalajs.nodejs.buffer.Buffer
 import io.scalajs.nodejs.tls
+import net.exoego.scalajs.types.util.Factory
 
 import scala.scalajs.js
 import scala.scalajs.js.|
 
-class RequestOptions(
-    var agent: js.UndefOr[Agent | Boolean] = js.undefined,
-    var auth: js.UndefOr[String] = js.undefined,
-    var createConnection: js.UndefOr[js.Function] = js.undefined,
-    var defaultPort: js.UndefOr[Int] = js.undefined,
-    var family: js.UndefOr[Int] = js.undefined,
-    var headers: js.UndefOr[js.Dictionary[js.Any]] = js.undefined,
-    var host: js.UndefOr[String] = js.undefined,
-    var hostname: js.UndefOr[String] = js.undefined,
-    var localAddress: js.UndefOr[String] = js.undefined,
-    var method: js.UndefOr[String] = js.undefined,
-    var path: js.UndefOr[String] = js.undefined,
-    var port: js.UndefOr[Int] = js.undefined,
-    var protocol: js.UndefOr[String] = js.undefined,
-    var setHost: js.UndefOr[Boolean] = js.undefined,
-    var socketPath: js.UndefOr[String] = js.undefined,
-    var timeout: js.UndefOr[Int] = js.undefined,
-    var servername: js.UndefOr[String],
-    var ca: js.UndefOr[tls.SecureData] = js.undefined,
-    var cert: js.UndefOr[tls.SecureData] = js.undefined,
-    var ciphers: js.UndefOr[String] = js.undefined,
-    var clientCertEngine: js.UndefOr[String] = js.undefined,
-    var crl: js.UndefOr[tls.SecureData] = js.undefined,
-    var dphram: js.UndefOr[String | Buffer] = js.undefined,
-    var ecdhCurve: js.UndefOr[String] = js.undefined,
-    var honorCihperOrder: js.UndefOr[Boolean] = js.undefined,
-    var key: js.UndefOr[tls.SecureData] = js.undefined,
-    var passphrase: js.UndefOr[String] = js.undefined,
-    var pfx: js.UndefOr[tls.SecureData | js.Array[tls.SecureDataObjectForm]] = js.undefined,
-    var rejectUnauthorized: js.UndefOr[Boolean] = js.undefined,
-    var secureOptions: js.UndefOr[Int] = js.undefined,
-    var secureProtocol: js.UndefOr[String] = js.undefined,
-    var sessionIdContext: js.UndefOr[String] = js.undefined
-) extends js.Object
+@Factory
+trait RequestOptions extends js.Object {
+  var agent: js.UndefOr[Agent | Boolean]                                   = js.undefined
+  var auth: js.UndefOr[String]                                             = js.undefined
+  var createConnection: js.UndefOr[js.Function]                            = js.undefined
+  var defaultPort: js.UndefOr[Int]                                         = js.undefined
+  var family: js.UndefOr[Int]                                              = js.undefined
+  var headers: js.UndefOr[js.Dictionary[js.Any]]                           = js.undefined
+  var host: js.UndefOr[String]                                             = js.undefined
+  var hostname: js.UndefOr[String]                                         = js.undefined
+  var localAddress: js.UndefOr[String]                                     = js.undefined
+  var method: js.UndefOr[String]                                           = js.undefined
+  var path: js.UndefOr[String]                                             = js.undefined
+  var port: js.UndefOr[Int]                                                = js.undefined
+  var protocol: js.UndefOr[String]                                         = js.undefined
+  var setHost: js.UndefOr[Boolean]                                         = js.undefined
+  var socketPath: js.UndefOr[String]                                       = js.undefined
+  var timeout: js.UndefOr[Int]                                             = js.undefined
+  var servername: js.UndefOr[String]                                       = js.undefined
+  var ca: js.UndefOr[tls.SecureData]                                       = js.undefined
+  var cert: js.UndefOr[tls.SecureData]                                     = js.undefined
+  var ciphers: js.UndefOr[String]                                          = js.undefined
+  var clientCertEngine: js.UndefOr[String]                                 = js.undefined
+  var crl: js.UndefOr[tls.SecureData]                                      = js.undefined
+  var dphram: js.UndefOr[String | Buffer]                                  = js.undefined
+  var ecdhCurve: js.UndefOr[String]                                        = js.undefined
+  var honorCihperOrder: js.UndefOr[Boolean]                                = js.undefined
+  var key: js.UndefOr[tls.SecureData]                                      = js.undefined
+  var passphrase: js.UndefOr[String]                                       = js.undefined
+  var pfx: js.UndefOr[tls.SecureData | js.Array[tls.SecureDataObjectForm]] = js.undefined
+  var rejectUnauthorized: js.UndefOr[Boolean]                              = js.undefined
+  var secureOptions: js.UndefOr[Int]                                       = js.undefined
+  var secureProtocol: js.UndefOr[String]                                   = js.undefined
+  var sessionIdContext: js.UndefOr[String]                                 = js.undefined
+}

--- a/app/current/src/main/scala/io/scalajs/nodejs/http/ServerOptions.scala
+++ b/app/current/src/main/scala/io/scalajs/nodejs/http/ServerOptions.scala
@@ -1,8 +1,11 @@
 package io.scalajs.nodejs.http
 
+import net.exoego.scalajs.types.util.Factory
+
 import scala.scalajs.js
 
-class ServerOptions(
-    var IncomingMessage: js.UndefOr[js.Function] = js.undefined,
-    var ServerResponse: js.UndefOr[js.Function] = js.undefined
-) extends js.Object
+@Factory
+trait ServerOptions extends js.Object {
+  var IncomingMessage: js.UndefOr[js.Function] = js.undefined
+  var ServerResponse: js.UndefOr[js.Function]  = js.undefined
+}

--- a/app/current/src/main/scala/io/scalajs/nodejs/http2/Http2ConnectOptions.scala
+++ b/app/current/src/main/scala/io/scalajs/nodejs/http2/Http2ConnectOptions.scala
@@ -5,54 +5,56 @@ import io.scalajs.nodejs.http.OnreadObject
 import io.scalajs.nodejs.{net, stream}
 import io.scalajs.nodejs.tls.{ALPNProtocols, SecureContext, TLSCertificate}
 import io.scalajs.nodejs.url.URL
+import _root_.net.exoego.scalajs.types.util.Factory
 
 import scala.scalajs.js
 
-class Http2ConnectOptions(
-    var maxDeflateDynamicTableSize: js.UndefOr[Int] = js.undefined,
-    var maxSessionMemory: js.UndefOr[Int] = js.undefined,
-    var maxHeaderListPairs: js.UndefOr[Int] = js.undefined,
-    var maxOutstandingPings: js.UndefOr[Int] = js.undefined,
-    var maxSendHeaderBlockLength: js.UndefOr[Int] = js.undefined,
-    var paddingStrategy: js.UndefOr[Int] = js.undefined,
-    var peerMaxConcurrentStreams: js.UndefOr[Int] = js.undefined,
-    var selectPadding: js.UndefOr[js.Function2[Int, Int, Int]] = js.undefined,
-    var settings: js.UndefOr[Http2Settings] = js.undefined,
-    // specific to connect
-    var maxReservedRemoteStreams: js.UndefOr[Int] = js.undefined,
-    var createConnection: js.UndefOr[js.Function2[URL, Http2ConnectOptions, stream.IDuplex]],
-    // From net.connect
-    // for socket.connect(option)
-    var port: js.UndefOr[Int] = js.undefined,
-    var host: js.UndefOr[String] = js.undefined,
-    var localAddress: js.UndefOr[String] = js.undefined,
-    var localPort: js.UndefOr[Int] = js.undefined,
-    var family: js.UndefOr[Int] = js.undefined,
-    var hints: js.UndefOr[Int] = js.undefined,
-    var lookup: js.UndefOr[js.Function1[String, Any]] = js.undefined,
-    var onread: js.UndefOr[OnreadObject] = js.undefined,
-    // for IPC connections
-    var path: js.UndefOr[String] = js.undefined,
-    // for new Socket(option)
-    var fd: js.UndefOr[Int] = js.undefined,
-    var allowHalfOpen: js.UndefOr[Boolean] = js.undefined,
-    var readable: js.UndefOr[Boolean] = js.undefined,
-    var writable: js.UndefOr[Int] = js.undefined,
-    // From tls.connect
-    var socket: js.UndefOr[stream.IDuplex] = js.undefined,
-    var servername: js.UndefOr[String] = js.undefined,
-    var checkServerIdentity: js.UndefOr[js.Function2[String, TLSCertificate, Any]] = js.undefined,
-    var minDHSize: js.UndefOr[Int] = js.undefined,
-    // TLSSocketOptions
-    var enableTrace: js.UndefOr[Boolean] = js.undefined,
-    var isServer: js.UndefOr[Boolean] = js.undefined,
-    var server: js.UndefOr[net.Server] = js.undefined,
-    var requestCert: js.UndefOr[Boolean] = js.undefined,
-    var rejectUnauthorized: js.UndefOr[Boolean] = js.undefined,
-    var NPNProtocols: js.UndefOr[Boolean] = js.undefined,
-    var ALPNProtocols: js.UndefOr[ALPNProtocols] = js.undefined,
-    var SNICallback: js.UndefOr[js.Function2[String, js.Function, Any]] = js.undefined,
-    var session: js.UndefOr[Buffer] = js.undefined,
-    var requestOCSP: js.UndefOr[Boolean] = js.undefined,
-    var secureContext: js.UndefOr[SecureContext] = js.undefined
-) extends js.Object
+@Factory
+trait Http2ConnectOptions extends js.Object {
+  var maxDeflateDynamicTableSize: js.UndefOr[Int]            = js.undefined
+  var maxSessionMemory: js.UndefOr[Int]                      = js.undefined
+  var maxHeaderListPairs: js.UndefOr[Int]                    = js.undefined
+  var maxOutstandingPings: js.UndefOr[Int]                   = js.undefined
+  var maxSendHeaderBlockLength: js.UndefOr[Int]              = js.undefined
+  var paddingStrategy: js.UndefOr[Int]                       = js.undefined
+  var peerMaxConcurrentStreams: js.UndefOr[Int]              = js.undefined
+  var selectPadding: js.UndefOr[js.Function2[Int, Int, Int]] = js.undefined
+  var settings: js.UndefOr[Http2Settings]                    = js.undefined
+  // specific to connect
+  var maxReservedRemoteStreams: js.UndefOr[Int]                                            = js.undefined
+  var createConnection: js.UndefOr[js.Function2[URL, Http2ConnectOptions, stream.IDuplex]] = js.undefined
+  // From net.connect
+  // for socket.connect(option)
+  var port: js.UndefOr[Int]                         = js.undefined
+  var host: js.UndefOr[String]                      = js.undefined
+  var localAddress: js.UndefOr[String]              = js.undefined
+  var localPort: js.UndefOr[Int]                    = js.undefined
+  var family: js.UndefOr[Int]                       = js.undefined
+  var hints: js.UndefOr[Int]                        = js.undefined
+  var lookup: js.UndefOr[js.Function1[String, Any]] = js.undefined
+  var onread: js.UndefOr[OnreadObject]              = js.undefined
+  // for IPC connections
+  var path: js.UndefOr[String] = js.undefined
+  // for new Socket(option)
+  var fd: js.UndefOr[Int]                = js.undefined
+  var allowHalfOpen: js.UndefOr[Boolean] = js.undefined
+  var readable: js.UndefOr[Boolean]      = js.undefined
+  var writable: js.UndefOr[Int]          = js.undefined
+  // From tls.connect
+  var socket: js.UndefOr[stream.IDuplex]                                         = js.undefined
+  var servername: js.UndefOr[String]                                             = js.undefined
+  var checkServerIdentity: js.UndefOr[js.Function2[String, TLSCertificate, Any]] = js.undefined
+  var minDHSize: js.UndefOr[Int]                                                 = js.undefined
+  // TLSSocketOptions
+  var enableTrace: js.UndefOr[Boolean]                                = js.undefined
+  var isServer: js.UndefOr[Boolean]                                   = js.undefined
+  var server: js.UndefOr[net.Server]                                  = js.undefined
+  var requestCert: js.UndefOr[Boolean]                                = js.undefined
+  var rejectUnauthorized: js.UndefOr[Boolean]                         = js.undefined
+  var NPNProtocols: js.UndefOr[Boolean]                               = js.undefined
+  var ALPNProtocols: js.UndefOr[ALPNProtocols]                        = js.undefined
+  var SNICallback: js.UndefOr[js.Function2[String, js.Function, Any]] = js.undefined
+  var session: js.UndefOr[Buffer]                                     = js.undefined
+  var requestOCSP: js.UndefOr[Boolean]                                = js.undefined
+  var secureContext: js.UndefOr[SecureContext]                        = js.undefined
+}

--- a/app/current/src/main/scala/io/scalajs/nodejs/http2/Http2Priority.scala
+++ b/app/current/src/main/scala/io/scalajs/nodejs/http2/Http2Priority.scala
@@ -1,10 +1,13 @@
 package io.scalajs.nodejs.http2
 
+import net.exoego.scalajs.types.util.Factory
+
 import scala.scalajs.js
 
-class Http2Priority(
-    var exclusive: js.UndefOr[Boolean],
-    var parent: js.UndefOr[Int],
-    var weight: js.UndefOr[Int],
-    var silent: js.UndefOr[Boolean]
-) extends js.Object
+@Factory
+trait Http2Priority extends js.Object {
+  var exclusive: js.UndefOr[Boolean] = js.undefined
+  var parent: js.UndefOr[Int]        = js.undefined
+  var weight: js.UndefOr[Int]        = js.undefined
+  var silent: js.UndefOr[Boolean]    = js.undefined
+}

--- a/app/current/src/main/scala/io/scalajs/nodejs/http2/Http2PushStreamOptions.scala
+++ b/app/current/src/main/scala/io/scalajs/nodejs/http2/Http2PushStreamOptions.scala
@@ -1,8 +1,11 @@
 package io.scalajs.nodejs.http2
 
+import net.exoego.scalajs.types.util.Factory
+
 import scala.scalajs.js
 
-class Http2PushStreamOptions(
-    var exclusive: js.UndefOr[Boolean],
-    var parent: js.UndefOr[Int]
-) extends js.Object
+@Factory
+trait Http2PushStreamOptions extends js.Object {
+  var exclusive: js.UndefOr[Boolean] = js.undefined
+  var parent: js.UndefOr[Int]        = js.undefined
+}

--- a/app/current/src/main/scala/io/scalajs/nodejs/http2/Http2RequestOptions.scala
+++ b/app/current/src/main/scala/io/scalajs/nodejs/http2/Http2RequestOptions.scala
@@ -1,11 +1,14 @@
 package io.scalajs.nodejs.http2
 
+import net.exoego.scalajs.types.util.Factory
+
 import scala.scalajs.js
 
-class Http2RequestOptions(
-    var endStream: js.UndefOr[Boolean] = js.undefined,
-    var exclusive: js.UndefOr[Boolean] = js.undefined,
-    var parent: js.UndefOr[Int] = js.undefined,
-    var weight: js.UndefOr[Int] = js.undefined,
-    var waitForTrailers: js.UndefOr[Boolean] = js.undefined
-) extends js.Object
+@Factory
+trait Http2RequestOptions extends js.Object {
+  var endStream: js.UndefOr[Boolean]       = js.undefined
+  var exclusive: js.UndefOr[Boolean]       = js.undefined
+  var parent: js.UndefOr[Int]              = js.undefined
+  var weight: js.UndefOr[Int]              = js.undefined
+  var waitForTrailers: js.UndefOr[Boolean] = js.undefined
+}

--- a/app/current/src/main/scala/io/scalajs/nodejs/http2/Http2RespondWithFDOptions.scala
+++ b/app/current/src/main/scala/io/scalajs/nodejs/http2/Http2RespondWithFDOptions.scala
@@ -1,10 +1,13 @@
 package io.scalajs.nodejs.http2
 
+import net.exoego.scalajs.types.util.Factory
+
 import scala.scalajs.js
 
-class Http2RespondWithFDOptions(
-    var statCheck: js.UndefOr[js.Function] = js.undefined,
-    var waitForTrailers: js.UndefOr[Boolean] = js.undefined,
-    var offset: js.UndefOr[Int] = js.undefined,
-    var length: js.UndefOr[Int] = js.undefined
-) extends js.Object
+@Factory
+trait Http2RespondWithFDOptions extends js.Object {
+  var statCheck: js.UndefOr[js.Function]   = js.undefined
+  var waitForTrailers: js.UndefOr[Boolean] = js.undefined
+  var offset: js.UndefOr[Int]              = js.undefined
+  var length: js.UndefOr[Int]              = js.undefined
+}

--- a/app/current/src/main/scala/io/scalajs/nodejs/http2/Http2RespondWithFileOptions.scala
+++ b/app/current/src/main/scala/io/scalajs/nodejs/http2/Http2RespondWithFileOptions.scala
@@ -1,11 +1,14 @@
 package io.scalajs.nodejs.http2
 
+import net.exoego.scalajs.types.util.Factory
+
 import scala.scalajs.js
 
-class Http2RespondWithFileOptions(
-    var statCheck: js.UndefOr[js.Function] = js.undefined,
-    var onError: js.UndefOr[js.Function] = js.undefined,
-    var waitForTrailers: js.UndefOr[Boolean] = js.undefined,
-    var offset: js.UndefOr[Int] = js.undefined,
-    var length: js.UndefOr[Int] = js.undefined
-) extends js.Object
+@Factory
+trait Http2RespondWithFileOptions extends js.Object {
+  var statCheck: js.UndefOr[js.Function]   = js.undefined
+  var onError: js.UndefOr[js.Function]     = js.undefined
+  var waitForTrailers: js.UndefOr[Boolean] = js.undefined
+  var offset: js.UndefOr[Int]              = js.undefined
+  var length: js.UndefOr[Int]              = js.undefined
+}

--- a/app/current/src/main/scala/io/scalajs/nodejs/http2/Http2ResponseOptions.scala
+++ b/app/current/src/main/scala/io/scalajs/nodejs/http2/Http2ResponseOptions.scala
@@ -1,8 +1,11 @@
 package io.scalajs.nodejs.http2
 
+import net.exoego.scalajs.types.util.Factory
+
 import scala.scalajs.js
 
-class Http2ResponseOptions(
-    var endStream: js.UndefOr[Boolean] = js.undefined,
-    var waitForTrailers: js.UndefOr[Boolean] = js.undefined
-) extends js.Object
+@Factory
+trait Http2ResponseOptions extends js.Object {
+  var endStream: js.UndefOr[Boolean]       = js.undefined
+  var waitForTrailers: js.UndefOr[Boolean] = js.undefined
+}

--- a/app/current/src/main/scala/io/scalajs/nodejs/http2/Http2SecureServerOptions.scala
+++ b/app/current/src/main/scala/io/scalajs/nodejs/http2/Http2SecureServerOptions.scala
@@ -2,52 +2,55 @@ package io.scalajs.nodejs.http2
 
 import io.scalajs.nodejs.buffer.Buffer
 import io.scalajs.nodejs.tls.{SecureContext, SecureData, SecureDataObjectForm}
+import net.exoego.scalajs.types.util.Factory
 
 import scala.scalajs.js
 import scala.scalajs.js.typedarray.{DataView, TypedArray}
 import scala.scalajs.js.|
 
-class Http2SecureServerOptions(
-    var allowHTTP1: js.UndefOr[Boolean] = js.undefined,
-    var maxDeflateDynamicTableSize: js.UndefOr[Int] = js.undefined,
-    var maxSessionMemory: js.UndefOr[Int] = js.undefined,
-    var maxHeaderListPairs: js.UndefOr[Int] = js.undefined,
-    var maxOutstandingPings: js.UndefOr[Int] = js.undefined,
-    var maxSendHeaderBlockLength: js.UndefOr[Int] = js.undefined,
-    var paddingStrategy: js.UndefOr[Int] = js.undefined,
-    var peerMaxConcurrentStreams: js.UndefOr[Int] = js.undefined,
-    var selectPadding: js.UndefOr[js.Function2[Int, Int, Int]] = js.undefined,
-    var settings: js.UndefOr[Http2Settings] = js.undefined,
-    var options: js.UndefOr[js.Array[String]] = js.undefined,
-    var ALPNProtocols: js.UndefOr[
-      js.Array[String] | js.Array[TypedArray[_, _]] | js.Array[DataView] | TypedArray[_, _] | DataView
-    ] = js.undefined,
-    var enableTrace: js.UndefOr[Boolean] = js.undefined,
-    var handshakeTimeout: js.UndefOr[Int] = js.undefined,
-    var rejectUnauthorized: js.UndefOr[Boolean] = js.undefined,
-    var requestCert: js.UndefOr[Boolean] = js.undefined,
-    var sessionTimeout: js.UndefOr[Int] = js.undefined,
-    var SNICallback: js.UndefOr[js.Function2[String, js.Function2[io.scalajs.nodejs.Error, SecureContext, Any], Any]],
-    var ticketKeys: js.UndefOr[Buffer] = js.undefined,
-// Options for net.createServers
-    var allowHalfOpen: js.UndefOr[Boolean] = js.undefined,
-    var pauseOnConnect: js.UndefOr[Boolean] = js.undefined,
-// Options for tls.createSecureContext
-    var ca: js.UndefOr[SecureData] = js.undefined,
-    var cert: js.UndefOr[SecureData] = js.undefined,
-    var sigalgs: js.UndefOr[String] = js.undefined,
-    var ciphers: js.UndefOr[String] = js.undefined,
-    var clientCertEngine: js.UndefOr[String] = js.undefined,
-    var crl: js.UndefOr[SecureData] = js.undefined,
-    var dphram: js.UndefOr[String | Buffer] = js.undefined,
-    var ecdhCurve: js.UndefOr[String] = js.undefined,
-    var honorCipherOrder: js.UndefOr[Boolean] = js.undefined,
-    var key: js.UndefOr[SecureData] = js.undefined,
-    var maxVersion: js.UndefOr[String] = js.undefined,
-    var minVersion: js.UndefOr[String] = js.undefined,
-    var passphrase: js.UndefOr[String] = js.undefined,
-    var pfx: js.UndefOr[SecureData | js.Array[SecureDataObjectForm]] = js.undefined,
-    var secureOptions: js.UndefOr[Int] = js.undefined,
-    var secureProtocol: js.UndefOr[String] = js.undefined,
-    var sessionIdContext: js.UndefOr[String] = js.undefined
-) extends js.Object
+@Factory
+trait Http2SecureServerOptions extends js.Object {
+  var allowHTTP1: js.UndefOr[Boolean]                        = js.undefined
+  var maxDeflateDynamicTableSize: js.UndefOr[Int]            = js.undefined
+  var maxSessionMemory: js.UndefOr[Int]                      = js.undefined
+  var maxHeaderListPairs: js.UndefOr[Int]                    = js.undefined
+  var maxOutstandingPings: js.UndefOr[Int]                   = js.undefined
+  var maxSendHeaderBlockLength: js.UndefOr[Int]              = js.undefined
+  var paddingStrategy: js.UndefOr[Int]                       = js.undefined
+  var peerMaxConcurrentStreams: js.UndefOr[Int]              = js.undefined
+  var selectPadding: js.UndefOr[js.Function2[Int, Int, Int]] = js.undefined
+  var settings: js.UndefOr[Http2Settings]                    = js.undefined
+  var options: js.UndefOr[js.Array[String]]                  = js.undefined
+  var ALPNProtocols: js.UndefOr[
+    js.Array[String] | js.Array[TypedArray[_, _]] | js.Array[DataView] | TypedArray[_, _] | DataView
+  ]                                           = js.undefined
+  var enableTrace: js.UndefOr[Boolean]        = js.undefined
+  var handshakeTimeout: js.UndefOr[Int]       = js.undefined
+  var rejectUnauthorized: js.UndefOr[Boolean] = js.undefined
+  var requestCert: js.UndefOr[Boolean]        = js.undefined
+  var sessionTimeout: js.UndefOr[Int]         = js.undefined
+  var SNICallback: js.UndefOr[js.Function2[String, js.Function2[io.scalajs.nodejs.Error, SecureContext, Any], Any]] =
+    js.undefined
+  var ticketKeys: js.UndefOr[Buffer] = js.undefined
+  // Options for net.createServers
+  var allowHalfOpen: js.UndefOr[Boolean]  = js.undefined
+  var pauseOnConnect: js.UndefOr[Boolean] = js.undefined
+  // Options for tls.createSecureContext
+  var ca: js.UndefOr[SecureData]                                   = js.undefined
+  var cert: js.UndefOr[SecureData]                                 = js.undefined
+  var sigalgs: js.UndefOr[String]                                  = js.undefined
+  var ciphers: js.UndefOr[String]                                  = js.undefined
+  var clientCertEngine: js.UndefOr[String]                         = js.undefined
+  var crl: js.UndefOr[SecureData]                                  = js.undefined
+  var dphram: js.UndefOr[String | Buffer]                          = js.undefined
+  var ecdhCurve: js.UndefOr[String]                                = js.undefined
+  var honorCipherOrder: js.UndefOr[Boolean]                        = js.undefined
+  var key: js.UndefOr[SecureData]                                  = js.undefined
+  var maxVersion: js.UndefOr[String]                               = js.undefined
+  var minVersion: js.UndefOr[String]                               = js.undefined
+  var passphrase: js.UndefOr[String]                               = js.undefined
+  var pfx: js.UndefOr[SecureData | js.Array[SecureDataObjectForm]] = js.undefined
+  var secureOptions: js.UndefOr[Int]                               = js.undefined
+  var secureProtocol: js.UndefOr[String]                           = js.undefined
+  var sessionIdContext: js.UndefOr[String]                         = js.undefined
+}

--- a/app/current/src/main/scala/io/scalajs/nodejs/http2/Http2ServerOptions.scala
+++ b/app/current/src/main/scala/io/scalajs/nodejs/http2/Http2ServerOptions.scala
@@ -1,23 +1,25 @@
 package io.scalajs.nodejs.http2
 
 import io.scalajs.nodejs.http
+import net.exoego.scalajs.types.util.Factory
 
 import scala.scalajs.js
 
-class Http2ServerOptions(
-    var maxDeflateDynamicTableSize: js.UndefOr[Int] = js.undefined,
-    var maxSessionMemory: js.UndefOr[Int] = js.undefined,
-    var maxHeaderListPairs: js.UndefOr[Int] = js.undefined,
-    var maxOutstandingPings: js.UndefOr[Int] = js.undefined,
-    var maxSendHeaderBlockLength: js.UndefOr[Int] = js.undefined,
-    var paddingStrategy: js.UndefOr[Int] = js.undefined,
-    var peerMaxConcurrentStreams: js.UndefOr[Int] = js.undefined,
-    var selectPadding: js.UndefOr[js.Function2[Int, Int, Int]] = js.undefined,
-    var settings: js.UndefOr[Http2Settings] = js.undefined,
-    var Http1IncomingMessage: js.UndefOr[js.ConstructorTag[http.IncomingMessage]] = js.undefined,
-    var Http1ServerResponse: js.UndefOr[js.ConstructorTag[http.ServerResponse]] = js.undefined,
-    var Http2ServerRequest: js.UndefOr[js.ConstructorTag[Http2ServerRequest]] = js.undefined,
-    var Http2ServerResponse: js.UndefOr[js.ConstructorTag[Http2ServerResponse]] = js.undefined,
-    var allowHalfOpen: js.UndefOr[Boolean] = js.undefined,
-    var pauseOnConnect: js.UndefOr[Boolean] = js.undefined
-) extends js.Object
+@Factory
+trait Http2ServerOptions extends js.Object {
+  var maxDeflateDynamicTableSize: js.UndefOr[Int]                               = js.undefined
+  var maxSessionMemory: js.UndefOr[Int]                                         = js.undefined
+  var maxHeaderListPairs: js.UndefOr[Int]                                       = js.undefined
+  var maxOutstandingPings: js.UndefOr[Int]                                      = js.undefined
+  var maxSendHeaderBlockLength: js.UndefOr[Int]                                 = js.undefined
+  var paddingStrategy: js.UndefOr[Int]                                          = js.undefined
+  var peerMaxConcurrentStreams: js.UndefOr[Int]                                 = js.undefined
+  var selectPadding: js.UndefOr[js.Function2[Int, Int, Int]]                    = js.undefined
+  var settings: js.UndefOr[Http2Settings]                                       = js.undefined
+  var Http1IncomingMessage: js.UndefOr[js.ConstructorTag[http.IncomingMessage]] = js.undefined
+  var Http1ServerResponse: js.UndefOr[js.ConstructorTag[http.ServerResponse]]   = js.undefined
+  var Http2ServerRequest: js.UndefOr[js.ConstructorTag[Http2ServerRequest]]     = js.undefined
+  var Http2ServerResponse: js.UndefOr[js.ConstructorTag[Http2ServerResponse]]   = js.undefined
+  var allowHalfOpen: js.UndefOr[Boolean]                                        = js.undefined
+  var pauseOnConnect: js.UndefOr[Boolean]                                       = js.undefined
+}

--- a/app/current/src/main/scala/io/scalajs/nodejs/http2/Http2Settings.scala
+++ b/app/current/src/main/scala/io/scalajs/nodejs/http2/Http2Settings.scala
@@ -1,13 +1,16 @@
 package io.scalajs.nodejs.http2
 
+import net.exoego.scalajs.types.util.Factory
+
 import scala.scalajs.js
 
-class Http2Settings(
-    var headerTableSize: js.UndefOr[Int] = js.undefined,
-    var enablePush: js.UndefOr[Boolean] = js.undefined,
-    var initialWindowSize: js.UndefOr[Int] = js.undefined,
-    var maxFrameSize: js.UndefOr[Int] = js.undefined,
-    var maxConcurrentStreams: js.UndefOr[Int] = js.undefined,
-    var maxHeaderListSize: js.UndefOr[Int] = js.undefined,
-    var enableConnectProtocol: js.UndefOr[Int] = js.undefined
-) extends js.Object {}
+@Factory
+trait Http2Settings extends js.Object {
+  var headerTableSize: js.UndefOr[Int]       = js.undefined
+  var enablePush: js.UndefOr[Boolean]        = js.undefined
+  var initialWindowSize: js.UndefOr[Int]     = js.undefined
+  var maxFrameSize: js.UndefOr[Int]          = js.undefined
+  var maxConcurrentStreams: js.UndefOr[Int]  = js.undefined
+  var maxHeaderListSize: js.UndefOr[Int]     = js.undefined
+  var enableConnectProtocol: js.UndefOr[Int] = js.undefined
+}

--- a/app/current/src/main/scala/io/scalajs/nodejs/https/AgentOptions.scala
+++ b/app/current/src/main/scala/io/scalajs/nodejs/https/AgentOptions.scala
@@ -2,31 +2,33 @@ package io.scalajs.nodejs.https
 
 import io.scalajs.nodejs.buffer.Buffer
 import io.scalajs.nodejs.tls
+import net.exoego.scalajs.types.util.Factory
 
 import scala.scalajs.js
 import scala.scalajs.js.|
 
-class AgentOptions(
-    var keepAlive: js.UndefOr[Boolean] = js.undefined,
-    var keepAliveMsecs: js.UndefOr[Int] = js.undefined,
-    var maxSockets: js.UndefOr[Double] = js.undefined,
-    var maxFreeSockets: js.UndefOr[Int] = js.undefined,
-    var timeout: js.UndefOr[Int] = js.undefined,
-    var maxCachedSessions: js.UndefOr[Int],
-    var servername: js.UndefOr[String],
-    var ca: js.UndefOr[tls.SecureData] = js.undefined,
-    var cert: js.UndefOr[tls.SecureData] = js.undefined,
-    var ciphers: js.UndefOr[String] = js.undefined,
-    var clientCertEngine: js.UndefOr[String] = js.undefined,
-    var crl: js.UndefOr[tls.SecureData] = js.undefined,
-    var dphram: js.UndefOr[String | Buffer] = js.undefined,
-    var ecdhCurve: js.UndefOr[String] = js.undefined,
-    var honorCihperOrder: js.UndefOr[Boolean] = js.undefined,
-    var key: js.UndefOr[tls.SecureData] = js.undefined,
-    var passphrase: js.UndefOr[String] = js.undefined,
-    var pfx: js.UndefOr[tls.SecureData | js.Array[tls.SecureDataObjectForm]] = js.undefined,
-    var rejectUnauthorized: js.UndefOr[Boolean] = js.undefined,
-    var secureOptions: js.UndefOr[Int] = js.undefined,
-    var secureProtocol: js.UndefOr[String] = js.undefined,
-    var sessionIdContext: js.UndefOr[String] = js.undefined
-) extends js.Object
+@Factory
+trait AgentOptions extends js.Object {
+  var keepAlive: js.UndefOr[Boolean]                                       = js.undefined
+  var keepAliveMsecs: js.UndefOr[Int]                                      = js.undefined
+  var maxSockets: js.UndefOr[Double]                                       = js.undefined
+  var maxFreeSockets: js.UndefOr[Int]                                      = js.undefined
+  var timeout: js.UndefOr[Int]                                             = js.undefined
+  var maxCachedSessions: js.UndefOr[Int]                                   = js.undefined
+  var servername: js.UndefOr[String]                                       = js.undefined
+  var ca: js.UndefOr[tls.SecureData]                                       = js.undefined
+  var cert: js.UndefOr[tls.SecureData]                                     = js.undefined
+  var ciphers: js.UndefOr[String]                                          = js.undefined
+  var clientCertEngine: js.UndefOr[String]                                 = js.undefined
+  var crl: js.UndefOr[tls.SecureData]                                      = js.undefined
+  var dphram: js.UndefOr[String | Buffer]                                  = js.undefined
+  var ecdhCurve: js.UndefOr[String]                                        = js.undefined
+  var honorCihperOrder: js.UndefOr[Boolean]                                = js.undefined
+  var key: js.UndefOr[tls.SecureData]                                      = js.undefined
+  var passphrase: js.UndefOr[String]                                       = js.undefined
+  var pfx: js.UndefOr[tls.SecureData | js.Array[tls.SecureDataObjectForm]] = js.undefined
+  var rejectUnauthorized: js.UndefOr[Boolean]                              = js.undefined
+  var secureOptions: js.UndefOr[Int]                                       = js.undefined
+  var secureProtocol: js.UndefOr[String]                                   = js.undefined
+  var sessionIdContext: js.UndefOr[String]                                 = js.undefined
+}

--- a/app/current/src/main/scala/io/scalajs/nodejs/https/ServerOptions.scala
+++ b/app/current/src/main/scala/io/scalajs/nodejs/https/ServerOptions.scala
@@ -2,43 +2,46 @@ package io.scalajs.nodejs.https
 
 import io.scalajs.nodejs.buffer.Buffer
 import io.scalajs.nodejs.tls.{SecureContext, SecureData, SecureDataObjectForm}
+import net.exoego.scalajs.types.util.Factory
 
 import scala.scalajs.js
 import scala.scalajs.js.typedarray.{DataView, TypedArray}
 import scala.scalajs.js.|
 
-class ServerOptions(
-    var ALPNProtocols: js.UndefOr[
-      js.Array[String] | js.Array[TypedArray[_, _]] | js.Array[DataView] | TypedArray[_, _] | DataView
-    ] = js.undefined,
-    var enableTrace: js.UndefOr[Boolean] = js.undefined,
-    var handshakeTimeout: js.UndefOr[Int] = js.undefined,
-    var rejectUnauthorized: js.UndefOr[Boolean] = js.undefined,
-    var requestCert: js.UndefOr[Boolean] = js.undefined,
-    var sessionTimeout: js.UndefOr[Int] = js.undefined,
-    var SNICallback: js.UndefOr[js.Function2[String, js.Function2[io.scalajs.nodejs.Error, SecureContext, Any], Any]],
-    var ticketKeys: js.UndefOr[Buffer] = js.undefined,
-    // Options for net.createServers
-    var allowHalfOpen: js.UndefOr[Boolean] = js.undefined,
-    var pauseOnConnect: js.UndefOr[Boolean] = js.undefined,
-    // Options for tls.createSecureContext
-    var ca: js.UndefOr[SecureData] = js.undefined,
-    var cert: js.UndefOr[SecureData] = js.undefined,
-    var sigalgs: js.UndefOr[String] = js.undefined,
-    var ciphers: js.UndefOr[String] = js.undefined,
-    var clientCertEngine: js.UndefOr[String] = js.undefined,
-    var crl: js.UndefOr[SecureData] = js.undefined,
-    var dphram: js.UndefOr[String | Buffer] = js.undefined,
-    var ecdhCurve: js.UndefOr[String] = js.undefined,
-    var honorCihperOrder: js.UndefOr[Boolean] = js.undefined,
-    var key: js.UndefOr[SecureData] = js.undefined,
-    var maxVersion: js.UndefOr[String] = js.undefined,
-    var minVersion: js.UndefOr[String] = js.undefined,
-    var passphrase: js.UndefOr[String] = js.undefined,
-    var pfx: js.UndefOr[SecureData | js.Array[SecureDataObjectForm]] = js.undefined,
-    var secureOptions: js.UndefOr[Int] = js.undefined,
-    var secureProtocol: js.UndefOr[String] = js.undefined,
-    var sessionIdContext: js.UndefOr[String] = js.undefined,
-    var IncomingMessage: js.UndefOr[js.Function] = js.undefined,
-    var ServerResponse: js.UndefOr[js.Function] = js.undefined
-) extends js.Object
+@Factory
+trait ServerOptions extends js.Object {
+  var ALPNProtocols: js.UndefOr[
+    js.Array[String] | js.Array[TypedArray[_, _]] | js.Array[DataView] | TypedArray[_, _] | DataView
+  ]                                           = js.undefined
+  var enableTrace: js.UndefOr[Boolean]        = js.undefined
+  var handshakeTimeout: js.UndefOr[Int]       = js.undefined
+  var rejectUnauthorized: js.UndefOr[Boolean] = js.undefined
+  var requestCert: js.UndefOr[Boolean]        = js.undefined
+  var sessionTimeout: js.UndefOr[Int]         = js.undefined
+  var SNICallback: js.UndefOr[js.Function2[String, js.Function2[io.scalajs.nodejs.Error, SecureContext, Any], Any]] =
+    js.undefined
+  var ticketKeys: js.UndefOr[Buffer] = js.undefined
+  // Options for net.createServers
+  var allowHalfOpen: js.UndefOr[Boolean]  = js.undefined
+  var pauseOnConnect: js.UndefOr[Boolean] = js.undefined
+  // Options for tls.createSecureContext
+  var ca: js.UndefOr[SecureData]                                   = js.undefined
+  var cert: js.UndefOr[SecureData]                                 = js.undefined
+  var sigalgs: js.UndefOr[String]                                  = js.undefined
+  var ciphers: js.UndefOr[String]                                  = js.undefined
+  var clientCertEngine: js.UndefOr[String]                         = js.undefined
+  var crl: js.UndefOr[SecureData]                                  = js.undefined
+  var dphram: js.UndefOr[String | Buffer]                          = js.undefined
+  var ecdhCurve: js.UndefOr[String]                                = js.undefined
+  var honorCihperOrder: js.UndefOr[Boolean]                        = js.undefined
+  var key: js.UndefOr[SecureData]                                  = js.undefined
+  var maxVersion: js.UndefOr[String]                               = js.undefined
+  var minVersion: js.UndefOr[String]                               = js.undefined
+  var passphrase: js.UndefOr[String]                               = js.undefined
+  var pfx: js.UndefOr[SecureData | js.Array[SecureDataObjectForm]] = js.undefined
+  var secureOptions: js.UndefOr[Int]                               = js.undefined
+  var secureProtocol: js.UndefOr[String]                           = js.undefined
+  var sessionIdContext: js.UndefOr[String]                         = js.undefined
+  var IncomingMessage: js.UndefOr[js.Function]                     = js.undefined
+  var ServerResponse: js.UndefOr[js.Function]                      = js.undefined
+}

--- a/app/current/src/main/scala/io/scalajs/nodejs/net/ListenerOptions.scala
+++ b/app/current/src/main/scala/io/scalajs/nodejs/net/ListenerOptions.scala
@@ -1,14 +1,17 @@
 package io.scalajs.nodejs.net
 
+import net.exoego.scalajs.types.util.Factory
+
 import scala.scalajs.js
 
-class ListenerOptions(
-    var host: js.UndefOr[String] = js.undefined,
-    var port: js.UndefOr[Int] = js.undefined,
-    var path: js.UndefOr[String] = js.undefined,
-    var backlog: js.UndefOr[Int] = js.undefined,
-    var exclusive: js.UndefOr[Boolean] = js.undefined,
-    var readableAll: js.UndefOr[Boolean] = js.undefined,
-    var writableAll: js.UndefOr[Boolean] = js.undefined,
-    var ipv6Only: js.UndefOr[Boolean] = js.undefined
-) extends js.Object
+@Factory
+trait ListenerOptions extends js.Object {
+  var host: js.UndefOr[String]         = js.undefined
+  var port: js.UndefOr[Int]            = js.undefined
+  var path: js.UndefOr[String]         = js.undefined
+  var backlog: js.UndefOr[Int]         = js.undefined
+  var exclusive: js.UndefOr[Boolean]   = js.undefined
+  var readableAll: js.UndefOr[Boolean] = js.undefined
+  var writableAll: js.UndefOr[Boolean] = js.undefined
+  var ipv6Only: js.UndefOr[Boolean]    = js.undefined
+}

--- a/app/current/src/main/scala/io/scalajs/nodejs/net/ServerOptions.scala
+++ b/app/current/src/main/scala/io/scalajs/nodejs/net/ServerOptions.scala
@@ -1,7 +1,11 @@
 package io.scalajs.nodejs.net
 
+import net.exoego.scalajs.types.util.Factory
+
 import scala.scalajs.js
 
-class ServerOptions(var allowHalfOpen: js.UndefOr[Boolean] = js.undefined,
-                    var pauseOnConnect: js.UndefOr[Boolean] = js.undefined
-) extends js.Object
+@Factory
+trait ServerOptions extends js.Object {
+  var allowHalfOpen: js.UndefOr[Boolean]  = js.undefined
+  var pauseOnConnect: js.UndefOr[Boolean] = js.undefined
+}

--- a/app/current/src/main/scala/io/scalajs/nodejs/net/SocketOptions.scala
+++ b/app/current/src/main/scala/io/scalajs/nodejs/net/SocketOptions.scala
@@ -1,21 +1,19 @@
 package io.scalajs.nodejs.net
 
 import io.scalajs.nodejs.FileDescriptor
+import net.exoego.scalajs.types.util.Factory
 
 import scala.scalajs.js
 
-/**
-  * Socket Options
-  *
-  * @param fd fd allows you to specify the existing file descriptor of socket. Set readable and/or writable to true to allow
-  *           reads and/or writes on this socket (NOTE: Works only when fd is passed). About allowHalfOpen, refer to createServer()
-  *           and 'end' event.
-  * @param allowHalfOpen
-  * @param readable
-  * @param writable
-  */
-class SocketOptions(var fd: js.UndefOr[FileDescriptor] = js.undefined,
-                    var allowHalfOpen: js.UndefOr[Boolean] = js.undefined,
-                    var readable: js.UndefOr[Boolean] = js.undefined,
-                    var writable: js.UndefOr[Boolean] = js.undefined
-) extends js.Object
+@Factory
+trait SocketOptions extends js.Object {
+
+  /** fd allows you to specify the existing file descriptor of socket. Set readable and/or writable to true to allow
+    * reads and/or writes on this socket (NOTE: Works only when fd is passed). About allowHalfOpen, refer to createServer()
+    * and 'end' event.
+    */
+  var fd: js.UndefOr[FileDescriptor]     = js.undefined
+  var allowHalfOpen: js.UndefOr[Boolean] = js.undefined
+  var readable: js.UndefOr[Boolean]      = js.undefined
+  var writable: js.UndefOr[Boolean]      = js.undefined
+}

--- a/app/current/src/main/scala/io/scalajs/nodejs/os/NetworkInterface.scala
+++ b/app/current/src/main/scala/io/scalajs/nodejs/os/NetworkInterface.scala
@@ -1,14 +1,18 @@
 package io.scalajs.nodejs.os
 
+import net.exoego.scalajs.types.util.Factory
+
 import scala.scalajs.js
 
 /**
   * Represents a Network Interface
   */
-class NetworkInterface(val address: String,
-                       val netmask: String,
-                       val family: String,
-                       val mac: String,
-                       val scopeid: js.UndefOr[Int],
-                       val internal: Boolean
-) extends js.Object
+@Factory
+trait NetworkInterface extends js.Object {
+  var address: String
+  var netmask: String
+  var family: String
+  var mac: String
+  var scopeid: js.UndefOr[Int] = js.undefined
+  var internal: Boolean
+}

--- a/app/current/src/main/scala/io/scalajs/nodejs/os/UserInfoObject.scala
+++ b/app/current/src/main/scala/io/scalajs/nodejs/os/UserInfoObject.scala
@@ -1,6 +1,7 @@
 package io.scalajs.nodejs.os
 
 import io.scalajs.nodejs.{GID, UID}
+import net.exoego.scalajs.types.util.Factory
 
 import scala.scalajs.js
 
@@ -8,5 +9,11 @@ import scala.scalajs.js
   * User Information Object
   * @example {{{ {"uid":501,"gid":20,"username":"ldaniels","homedir":"/Users/ldaniels","shell":"/bin/bash"} }}}
   */
-class UserInfoObject(val uid: UID, val gid: GID, val username: String, val homedir: String, val shell: String)
-    extends js.Object
+@Factory
+trait UserInfoObject extends js.Object {
+  var uid: UID
+  var gid: GID
+  var username: String
+  var homedir: String
+  var shell: String
+}

--- a/app/current/src/main/scala/io/scalajs/nodejs/os/UserInfoOptions.scala
+++ b/app/current/src/main/scala/io/scalajs/nodejs/os/UserInfoOptions.scala
@@ -1,12 +1,13 @@
 package io.scalajs.nodejs.os
 
+import net.exoego.scalajs.types.util.Factory
+
 import scala.scalajs.js
 
-/**
-  * User Info Options
-  */
-class UserInfoOptions(var encoding: js.UndefOr[String] = js.undefined,
-                      var username: js.UndefOr[String] = js.undefined,
-                      var shell: js.UndefOr[String] = js.undefined,
-                      var homedir: js.UndefOr[String] = js.undefined
-) extends js.Object
+@Factory
+trait UserInfoOptions extends js.Object {
+  var encoding: js.UndefOr[String] = js.undefined
+  var username: js.UndefOr[String] = js.undefined
+  var shell: js.UndefOr[String]    = js.undefined
+  var homedir: js.UndefOr[String]  = js.undefined
+}

--- a/app/current/src/main/scala/io/scalajs/nodejs/path/PathObject.scala
+++ b/app/current/src/main/scala/io/scalajs/nodejs/path/PathObject.scala
@@ -1,13 +1,14 @@
 package io.scalajs.nodejs.path
 
+import net.exoego.scalajs.types.util.Factory
+
 import scala.scalajs.js
 
-/**
-  * Path Object
-  */
-class PathObject(var root: js.UndefOr[String] = js.undefined,
-                 var dir: js.UndefOr[String] = js.undefined,
-                 var base: js.UndefOr[String] = js.undefined,
-                 var ext: js.UndefOr[String] = js.undefined,
-                 var name: js.UndefOr[String] = js.undefined
-) extends js.Object
+@Factory
+trait PathObject extends js.Object {
+  var root: js.UndefOr[String] = js.undefined
+  var dir: js.UndefOr[String]  = js.undefined
+  var base: js.UndefOr[String] = js.undefined
+  var ext: js.UndefOr[String]  = js.undefined
+  var name: js.UndefOr[String] = js.undefined
+}

--- a/app/current/src/main/scala/io/scalajs/nodejs/process/Process.scala
+++ b/app/current/src/main/scala/io/scalajs/nodejs/process/Process.scala
@@ -3,6 +3,7 @@ package io.scalajs.nodejs.process
 import com.thoughtworks.{enableIf, enableMembersIf}
 import io.scalajs.nodejs.events.IEventEmitter
 import io.scalajs.nodejs.tty.{ReadStream, WriteStream}
+import net.exoego.scalajs.types.util.Factory
 
 import scala.scalajs.js
 import scala.scalajs.js.annotation.JSGlobal
@@ -408,12 +409,10 @@ trait ReleaseInfo extends js.Object {
   var lts: js.UndefOr[String]    = js.native
 }
 
-/**
-  * Transfer Options
-  */
-class TransferOptions(
-    var keepOpen: js.UndefOr[Boolean] = js.undefined
-) extends js.Object {}
+@Factory
+trait TransferOptions extends js.Object {
+  var keepOpen: js.UndefOr[Boolean] = js.undefined
+}
 
 /**
   * Version Information
@@ -445,12 +444,13 @@ trait CpuUsage extends js.Object {
   val system: Int = js.native
 }
 
-class WarningOptions(
-    var `type`: js.UndefOr[String] = js.undefined,
-    var code: js.UndefOr[String] = js.undefined,
-    var detail: js.UndefOr[String] = js.undefined,
-    var ctor: js.UndefOr[js.Function] = js.undefined
-) extends js.Object {}
+@Factory
+trait WarningOptions extends js.Object {
+  var `type`: js.UndefOr[String]    = js.undefined
+  var code: js.UndefOr[String]      = js.undefined
+  var detail: js.UndefOr[String]    = js.undefined
+  var ctor: js.UndefOr[js.Function] = js.undefined
+}
 
 @js.native
 trait HrTime extends js.Function1[js.Array[Int], js.Array[Int]] with js.Function0[js.Array[Int]] {

--- a/app/current/src/main/scala/io/scalajs/nodejs/querystring/QueryDecodeOptions.scala
+++ b/app/current/src/main/scala/io/scalajs/nodejs/querystring/QueryDecodeOptions.scala
@@ -1,15 +1,19 @@
 package io.scalajs.nodejs.querystring
 
+import net.exoego.scalajs.types.util.Factory
+
 import scala.scalajs.js
 
-/**
-  * Query String Decode Options
-  * @param decodeURIComponent The function to use when decoding percent-encoded characters in the query string.
-  *                           Defaults to querystring.unescape().
-  * @param maxKeys            Specifies the maximum number of keys to parse. Defaults to 1000. Specify 0 to remove
-  *                           key counting limitations. The querystring.parse() method parses a URL query string (str)
-  *                           into a collection of key and value pairs.
-  */
-class QueryDecodeOptions(var decodeURIComponent: js.UndefOr[js.Function] = js.undefined,
-                         var maxKeys: js.UndefOr[Int] = js.undefined
-) extends js.Object
+@Factory
+trait QueryDecodeOptions extends js.Object {
+
+  /** The function to use when decoding percent-encoded characters in the query string.
+    * Defaults to querystring.unescape().
+    */
+  var decodeURIComponent: js.UndefOr[js.Function] = js.undefined
+
+  /** Specifies the maximum number of keys to parse. Defaults to 1000. Specify 0 to remove key counting limitations.
+    * The querystring.parse() method parses a URL query string into a collection of key and value pairs.
+    */
+  var maxKeys: js.UndefOr[Int] = js.undefined
+}

--- a/app/current/src/main/scala/io/scalajs/nodejs/querystring/QueryEncodeOptions.scala
+++ b/app/current/src/main/scala/io/scalajs/nodejs/querystring/QueryEncodeOptions.scala
@@ -2,9 +2,10 @@ package io.scalajs.nodejs.querystring
 
 import scala.scalajs.js
 
-/**
-  * Query String Encode Options
-  * @param encodeURIComponent The function to use when converting URL-unsafe characters to percent-encoding in
-  *                           the query string. Defaults to querystring.escape().
-  */
-class QueryEncodeOptions(var encodeURIComponent: js.UndefOr[js.Function] = js.undefined) extends js.Object
+trait QueryEncodeOptions extends js.Object {
+
+  /** The function to use when converting URL-unsafe characters to percent-encoding in
+    * the query string. Defaults to querystring.escape().
+    */
+  var encodeURIComponent: js.UndefOr[js.Function] = js.undefined
+}

--- a/app/current/src/main/scala/io/scalajs/nodejs/readline/Interface.scala
+++ b/app/current/src/main/scala/io/scalajs/nodejs/readline/Interface.scala
@@ -1,6 +1,7 @@
 package io.scalajs.nodejs.readline
 
 import io.scalajs.nodejs.events.IEventEmitter
+import net.exoego.scalajs.types.util.Factory
 
 import scala.scalajs.js
 
@@ -84,9 +85,10 @@ trait Interface extends IEventEmitter {
   // TODO: [Symbol.asyncIterator]()
 }
 
-class Key(
-    var ctrl: js.UndefOr[Boolean] = js.undefined,
-    var meta: js.UndefOr[Boolean] = js.undefined,
-    var shift: js.UndefOr[Boolean] = js.undefined,
-    var name: js.UndefOr[String] = js.undefined
-) extends js.Object
+@Factory
+trait Key extends js.Object {
+  var ctrl: js.UndefOr[Boolean]  = js.undefined
+  var meta: js.UndefOr[Boolean]  = js.undefined
+  var shift: js.UndefOr[Boolean] = js.undefined
+  var name: js.UndefOr[String]   = js.undefined
+}

--- a/app/current/src/main/scala/io/scalajs/nodejs/readline/ReadlineOptions.scala
+++ b/app/current/src/main/scala/io/scalajs/nodejs/readline/ReadlineOptions.scala
@@ -1,20 +1,19 @@
 package io.scalajs.nodejs.readline
 
 import io.scalajs.nodejs.stream.{IReadable, IWritable}
+import net.exoego.scalajs.types.util.Factory
 
 import scala.scalajs.js
 
-/**
-  * Readline Options
-  */
-class ReadlineOptions(
-    var input: js.UndefOr[IReadable] = js.undefined,
-    var output: js.UndefOr[IWritable] = js.undefined,
-    var completer: js.UndefOr[js.Function] = js.undefined,
-    var terminal: js.UndefOr[Boolean] = js.undefined,
-    var historySize: js.UndefOr[Int] = js.undefined,
-    var prompt: js.UndefOr[String] = js.undefined,
-    var crlfDelay: js.UndefOr[Double] = js.undefined,
-    var removeHistoryDuplicates: js.UndefOr[Boolean] = js.undefined,
-    var escapeCodeTimeout: js.UndefOr[Double] = js.undefined
-) extends js.Object
+@Factory
+trait ReadlineOptions extends js.Object {
+  var input: js.UndefOr[IReadable]                 = js.undefined
+  var output: js.UndefOr[IWritable]                = js.undefined
+  var completer: js.UndefOr[js.Function]           = js.undefined
+  var terminal: js.UndefOr[Boolean]                = js.undefined
+  var historySize: js.UndefOr[Int]                 = js.undefined
+  var prompt: js.UndefOr[String]                   = js.undefined
+  var crlfDelay: js.UndefOr[Double]                = js.undefined
+  var removeHistoryDuplicates: js.UndefOr[Boolean] = js.undefined
+  var escapeCodeTimeout: js.UndefOr[Double]        = js.undefined
+}

--- a/app/current/src/main/scala/io/scalajs/nodejs/repl/REPL.scala
+++ b/app/current/src/main/scala/io/scalajs/nodejs/repl/REPL.scala
@@ -1,6 +1,7 @@
 package io.scalajs.nodejs.repl
 
 import io.scalajs.nodejs.stream
+import net.exoego.scalajs.types.util.Factory
 
 import scala.scalajs.js
 import scala.scalajs.js.annotation.JSImport
@@ -19,20 +20,21 @@ trait REPL extends js.Object {
   def start(prompt: String): REPLServer                    = js.native
 }
 
-class StartOptions(
-    var prompt: js.UndefOr[String] = js.undefined,
-    var input: js.UndefOr[stream.IReadable] = js.undefined,
-    var output: js.UndefOr[stream.IWritable] = js.undefined,
-    var terminal: js.UndefOr[Boolean] = js.undefined,
-    var eval: js.UndefOr[js.Function4[String, js.Object, String, js.Function, Any]] = js.undefined,
-    var useColors: js.UndefOr[Boolean] = js.undefined,
-    var useGlobal: js.UndefOr[Boolean] = js.undefined,
-    var ignoreUndefined: js.UndefOr[Boolean] = js.undefined,
-    var writer: js.UndefOr[js.Function1[js.Any, Any]] = js.undefined,
-    var completer: js.UndefOr[js.Function] = js.undefined,
-    var replMode: js.UndefOr[js.Symbol] = js.undefined,
-    var breakEvalOnSigint: js.UndefOr[Boolean] = js.undefined
-) extends js.Object
+@Factory
+trait StartOptions extends js.Object {
+  var prompt: js.UndefOr[String]                                                  = js.undefined
+  var input: js.UndefOr[stream.IReadable]                                         = js.undefined
+  var output: js.UndefOr[stream.IWritable]                                        = js.undefined
+  var terminal: js.UndefOr[Boolean]                                               = js.undefined
+  var eval: js.UndefOr[js.Function4[String, js.Object, String, js.Function, Any]] = js.undefined
+  var useColors: js.UndefOr[Boolean]                                              = js.undefined
+  var useGlobal: js.UndefOr[Boolean]                                              = js.undefined
+  var ignoreUndefined: js.UndefOr[Boolean]                                        = js.undefined
+  var writer: js.UndefOr[js.Function1[js.Any, Any]]                               = js.undefined
+  var completer: js.UndefOr[js.Function]                                          = js.undefined
+  var replMode: js.UndefOr[js.Symbol]                                             = js.undefined
+  var breakEvalOnSigint: js.UndefOr[Boolean]                                      = js.undefined
+}
 
 /**
   * REPL Singleton

--- a/app/current/src/main/scala/io/scalajs/nodejs/repl/REPLOptions.scala
+++ b/app/current/src/main/scala/io/scalajs/nodejs/repl/REPLOptions.scala
@@ -4,41 +4,55 @@ import io.scalajs.nodejs.stream.{IReadable, IWritable}
 
 import scala.scalajs.js
 
-/**
-  * REPL Options
-  * @param prompt          the prompt and stream for all I/O. Defaults to > .
-  * @param input           the readable stream to listen to. Defaults to process.stdin.
-  * @param output          the writable stream to write readline data to. Defaults to process.stdout.
-  * @param terminal        pass true if the stream should be treated like a TTY, and have ANSI/VT100 escape codes written to it.
-  *                        Defaults to checking isTTY on the output stream upon instantiation.
-  * @param eval            function that will be used to eval each given line. Defaults to an async wrapper for eval().
-  *                        See below for an example of a custom eval.
-  * @param useColors       a boolean which specifies whether or not the writer function should output colors.
-  *                        If a different writer function is set then this does nothing. Defaults to the repl's terminal value.
-  * @param useGlobal       if set to true, then the repl will use the global object, instead of running scripts in a separate context.
-  *                        Defaults to false.
-  * @param ignoreUndefined if set to true, then the repl will not output the return value of command if it's undefined.
-  *                        Defaults to false.
-  * @param writer          the function to invoke for each command that gets evaluated which returns the formatting
-  *                        (including coloring) to display. Defaults to util.inspect.
-  * @param replMode        controls whether the repl runs all commands in strict mode, default mode, or a hybrid mode ("magic" mode.)
-  *                        Acceptable values are:
-  *                        <ul>
-  *                        <li>repl.REPL_MODE_SLOPPY - run commands in sloppy mode.</li>
-  *                        <li>repl.REPL_MODE_STRICT - run commands in strict mode. This is equivalent to prefacing every
-  *                        repl statement with 'use strict'.</li>
-  *                        <li>repl.REPL_MODE_MAGIC - attempt to run commands in default mode. If they fail to parse,
-  *                        re-try in strict mode.</li>
-  *                        </ul>
-  */
-class REPLOptions(var prompt: js.UndefOr[String] = js.undefined,
-                  var input: js.UndefOr[IReadable] = js.undefined,
-                  var output: js.UndefOr[IWritable] = js.undefined,
-                  var terminal: js.UndefOr[Boolean] = js.undefined,
-                  var eval: js.UndefOr[js.Function] = js.undefined,
-                  var useColors: js.UndefOr[Boolean] = js.undefined,
-                  var useGlobal: js.UndefOr[Boolean] = js.undefined,
-                  var ignoreUndefined: js.UndefOr[Boolean] = js.undefined,
-                  var writer: js.UndefOr[js.Function] = js.undefined,
-                  var replMode: js.UndefOr[String] = js.undefined
-) extends js.Object
+trait REPLOptions extends js.Object {
+
+  /** the prompt and stream for all I/O. Defaults to > . */
+  var prompt: js.UndefOr[String] = js.undefined
+
+  /** the readable stream to listen to. Defaults to process.stdin. */
+  var input: js.UndefOr[IReadable] = js.undefined
+
+  /** the writable stream to write readline data to. Defaults to process.stdout.*/
+  var output: js.UndefOr[IWritable] = js.undefined
+
+  /** pass true if the stream should be treated like a TTY, and have ANSI/VT100 escape codes written to it.
+    * Defaults to checking isTTY on the output stream upon instantiation.
+    */
+  var terminal: js.UndefOr[Boolean] = js.undefined
+
+  /** function that will be used to eval each given line. Defaults to an async wrapper for eval().
+    * See below for an example of a custom eval.
+    */
+  var eval: js.UndefOr[js.Function] = js.undefined
+
+  /** a boolean which specifies whether or not the writer function should output colors.
+    *                        If a different writer function is set then this does nothing. Defaults to the repl's terminal value. */
+  var useColors: js.UndefOr[Boolean] = js.undefined
+
+  /** if set to true, then the repl will use the global object, instead of running scripts in a separate context.
+    * Defaults to false.
+    */
+  var useGlobal: js.UndefOr[Boolean] = js.undefined
+
+  /** if set to true, then the repl will not output the return value of command if it's undefined.
+    * Defaults to false.
+    */
+  var ignoreUndefined: js.UndefOr[Boolean] = js.undefined
+
+  /** the function to invoke for each command that gets evaluated which returns the formatting
+    * (including coloring) to display. Defaults to util.inspect.
+    */
+  var writer: js.UndefOr[js.Function] = js.undefined
+
+  /** controls whether the repl runs all commands in strict mode, default mode, or a hybrid mode ("magic" mode.)
+    * Acceptable values are:
+    * <ul>
+    * <li>repl.REPL_MODE_SLOPPY - run commands in sloppy mode.</li>
+    * <li>repl.REPL_MODE_STRICT - run commands in strict mode. This is equivalent to prefacing every
+    * repl statement with 'use strict'.</li>
+    * <li>repl.REPL_MODE_MAGIC - attempt to run commands in default mode. If they fail to parse,
+    * re-try in strict mode.</li>
+    * </ul>
+    */
+  var replMode: js.UndefOr[String] = js.undefined
+}

--- a/app/current/src/main/scala/io/scalajs/nodejs/repl/REPLServer.scala
+++ b/app/current/src/main/scala/io/scalajs/nodejs/repl/REPLServer.scala
@@ -3,6 +3,7 @@ package io.scalajs.nodejs.repl
 import com.thoughtworks.enableIf
 import io.scalajs.nodejs.events.IEventEmitter
 import io.scalajs.nodejs.readline.Interface
+import net.exoego.scalajs.types.util.Factory
 
 import scala.scalajs.js
 import scala.scalajs.js.|
@@ -61,7 +62,8 @@ trait REPLServer extends IEventEmitter with Interface {
     js.native
 }
 
-class DefinedCommand(
-    var action: js.Function1[String, Any],
-    var help: js.UndefOr[String] = js.undefined
-) extends js.Object
+@Factory
+trait DefinedCommand extends js.Object {
+  var action: js.Function1[String, Any]
+  var help: js.UndefOr[String] = js.undefined
+}

--- a/app/current/src/main/scala/io/scalajs/nodejs/stream/FinishedOptions.scala
+++ b/app/current/src/main/scala/io/scalajs/nodejs/stream/FinishedOptions.scala
@@ -1,9 +1,12 @@
 package io.scalajs.nodejs.stream
 
+import net.exoego.scalajs.types.util.Factory
+
 import scala.scalajs.js
 
-class FinishedOptions(
-    var error: js.UndefOr[Boolean] = js.undefined,
-    var readable: js.UndefOr[Boolean] = js.undefined,
-    var writable: js.UndefOr[Boolean] = js.undefined
-) extends js.Object
+@Factory
+trait FinishedOptions extends js.Object {
+  var error: js.UndefOr[Boolean]    = js.undefined
+  var readable: js.UndefOr[Boolean] = js.undefined
+  var writable: js.UndefOr[Boolean] = js.undefined
+}

--- a/app/current/src/main/scala/io/scalajs/nodejs/stream/Stream.scala
+++ b/app/current/src/main/scala/io/scalajs/nodejs/stream/Stream.scala
@@ -2,6 +2,7 @@ package io.scalajs.nodejs
 package stream
 
 import com.thoughtworks.enableIf
+import _root_.net.exoego.scalajs.types.util.Factory
 
 import scala.scalajs.js.|
 import io.scalajs.nodejs.buffer.Buffer
@@ -223,21 +224,25 @@ sealed trait IReadable extends LegacyStream {
   def wrap(stream: LegacyStream): Unit = js.native
 }
 
-class ReadableOptions(
-    var highWaterMark: js.UndefOr[Int] = js.undefined,
-    var encoding: js.UndefOr[String] = js.undefined,
-    var objectMode: js.UndefOr[Boolean] = js.undefined,
-    var emitClose: js.UndefOr[Boolean] = js.undefined,
-    var read: js.UndefOr[js.Function] = js.undefined,
-    var destroy: js.UndefOr[js.Function] = js.undefined,
-    var autoDestroy: js.UndefOr[Boolean] = js.undefined
-) extends js.Object
+@Factory
+trait ReadableOptions extends js.Object {
+  var highWaterMark: js.UndefOr[Int]   = js.undefined
+  var encoding: js.UndefOr[String]     = js.undefined
+  var objectMode: js.UndefOr[Boolean]  = js.undefined
+  var emitClose: js.UndefOr[Boolean]   = js.undefined
+  var read: js.UndefOr[js.Function]    = js.undefined
+  var destroy: js.UndefOr[js.Function] = js.undefined
+  var autoDestroy: js.UndefOr[Boolean] = js.undefined
+}
 
-/**
-  * Readable Pipe Options
-  * @param end End the writer when the reader ends. Defaults to true.
-  */
-class ReadablePipeOptions(var end: js.UndefOr[Boolean] = js.undefined) extends js.Object
+@Factory
+trait ReadablePipeOptions extends js.Object {
+
+  /** End the writer when the reader ends.
+    *  Defaults to true.
+    */
+  var end: js.UndefOr[Boolean] = js.undefined
+}
 
 /**
   * Readable State
@@ -307,17 +312,19 @@ sealed trait IWritable extends LegacyStream {
   def write(chunk: String, encoding: String, callback: js.Function1[Error, Any]): Boolean        = js.native
 }
 
-class WritableOptions(var highWaterMark: js.UndefOr[Int] = js.undefined,
-                      var decodeStrings: js.UndefOr[Boolean] = js.undefined,
-                      var defaultEncoding: js.UndefOr[String] = js.undefined,
-                      var objectMode: js.UndefOr[Boolean] = js.undefined,
-                      var emitClose: js.UndefOr[Boolean] = js.undefined,
-                      var write: js.UndefOr[js.Function] = js.undefined,
-                      var writev: js.UndefOr[js.Function] = js.undefined,
-                      var destroy: js.UndefOr[js.Function] = js.undefined,
-                      var `final`: js.UndefOr[js.Function] = js.undefined,
-                      var autoDestroy: js.UndefOr[Boolean] = js.undefined
-) extends js.Object
+@Factory
+trait WritableOptions extends js.Object {
+  var highWaterMark: js.UndefOr[Int]      = js.undefined
+  var decodeStrings: js.UndefOr[Boolean]  = js.undefined
+  var defaultEncoding: js.UndefOr[String] = js.undefined
+  var objectMode: js.UndefOr[Boolean]     = js.undefined
+  var emitClose: js.UndefOr[Boolean]      = js.undefined
+  var write: js.UndefOr[js.Function]      = js.undefined
+  var writev: js.UndefOr[js.Function]     = js.undefined
+  var destroy: js.UndefOr[js.Function]    = js.undefined
+  var `final`: js.UndefOr[js.Function]    = js.undefined
+  var autoDestroy: js.UndefOr[Boolean]    = js.undefined
+}
 
 /**
   * Duplex Interface
@@ -330,20 +337,26 @@ sealed trait IDuplex extends IReadable with IWritable {
 @js.native
 sealed trait ITransform extends IDuplex
 
-/**
-  * Duplex Options
-  * @param allowHalfOpen      If set to false, then the stream will automatically end the readable side
-  *                           when the writable side ends and vice versa (Default: true).
-  * @param readableObjectMode Sets objectMode for readable side of the stream. Has no effect if objectMode is true
-  *                           (Default: false).
-  * @param writableObjectMode Sets objectMode for writable side of the stream. Has no effect if objectMode is true
-  *                           (Default: false).
-  */
-class DuplexOptions(var allowHalfOpen: js.UndefOr[Boolean] = js.undefined,
-                    var readableObjectMode: js.UndefOr[Boolean] = js.undefined,
-                    var writableObjectMode: js.UndefOr[Boolean] = js.undefined
-) extends js.Object
+@Factory
+trait DuplexOptions extends js.Object {
 
+  /** If set to false, then the stream will automatically end the readable side
+    *  when the writable side ends and vice versa (Default: true).
+    */
+  var allowHalfOpen: js.UndefOr[Boolean] = js.undefined
+
+  /** Sets objectMode for readable side of the stream. Has no effect if objectMode is true
+    *  (Default: false).
+    */
+  var readableObjectMode: js.UndefOr[Boolean] = js.undefined
+
+  /** Sets objectMode for writable side of the stream. Has no effect if objectMode is true
+    *  (Default: false).
+    */
+  var writableObjectMode: js.UndefOr[Boolean] = js.undefined
+}
+
+// TODO: Use Factory macro
 class TransformOptions(var transform: js.UndefOr[js.Function] = js.undefined,
                        var flush: js.UndefOr[js.Function] = js.undefined
 ) extends js.Object

--- a/app/current/src/main/scala/io/scalajs/nodejs/tls/ConnectOptions.scala
+++ b/app/current/src/main/scala/io/scalajs/nodejs/tls/ConnectOptions.scala
@@ -2,28 +2,31 @@ package io.scalajs.nodejs.tls
 
 import io.scalajs.nodejs.buffer.Buffer
 import io.scalajs.nodejs.{net, stream}
+import _root_.net.exoego.scalajs.types.util.Factory
 
 import scala.scalajs.js
 
-class ConnectOptions(
-    var host: js.UndefOr[String] = js.undefined,
-    var port: js.UndefOr[Int] = js.undefined,
-    var path: js.UndefOr[String] = js.undefined,
-    var socket: js.UndefOr[stream.IDuplex] = js.undefined,
-    var allowHalfOpen: js.UndefOr[Boolean] = js.undefined,
-    var servername: js.UndefOr[String] = js.undefined,
-    var checkServerIdentity: js.UndefOr[js.Function2[String, TLSCertificate, Any]] = js.undefined,
-    var minDHSize: js.UndefOr[Int] = js.undefined,
-    // TLSSocketOptions
-    var enableTrace: js.UndefOr[Boolean] = js.undefined,
-    var isServer: js.UndefOr[Boolean] = js.undefined,
-    var server: js.UndefOr[net.Server] = js.undefined,
-    var requestCert: js.UndefOr[Boolean] = js.undefined,
-    var rejectUnauthorized: js.UndefOr[Boolean] = js.undefined,
-    var NPNProtocols: js.UndefOr[Boolean] = js.undefined,
-    var ALPNProtocols: js.UndefOr[ALPNProtocols] = js.undefined,
-    var SNICallback: js.UndefOr[js.Function2[String, js.Function, Any]] = js.undefined,
-    var session: js.UndefOr[Buffer] = js.undefined,
-    var requestOCSP: js.UndefOr[Boolean] = js.undefined,
-    var secureContext: js.UndefOr[SecureContext] = js.undefined
-) extends js.Object
+@Factory
+trait ConnectOptions extends js.Object {
+  var host: js.UndefOr[String]                                                   = js.undefined
+  var port: js.UndefOr[Int]                                                      = js.undefined
+  var path: js.UndefOr[String]                                                   = js.undefined
+  var socket: js.UndefOr[stream.IDuplex]                                         = js.undefined
+  var allowHalfOpen: js.UndefOr[Boolean]                                         = js.undefined
+  var servername: js.UndefOr[String]                                             = js.undefined
+  var checkServerIdentity: js.UndefOr[js.Function2[String, TLSCertificate, Any]] = js.undefined
+  var minDHSize: js.UndefOr[Int]                                                 = js.undefined
+
+  // TLSSocketOptions
+  var enableTrace: js.UndefOr[Boolean]                                = js.undefined
+  var isServer: js.UndefOr[Boolean]                                   = js.undefined
+  var server: js.UndefOr[net.Server]                                  = js.undefined
+  var requestCert: js.UndefOr[Boolean]                                = js.undefined
+  var rejectUnauthorized: js.UndefOr[Boolean]                         = js.undefined
+  var NPNProtocols: js.UndefOr[Boolean]                               = js.undefined
+  var ALPNProtocols: js.UndefOr[ALPNProtocols]                        = js.undefined
+  var SNICallback: js.UndefOr[js.Function2[String, js.Function, Any]] = js.undefined
+  var session: js.UndefOr[Buffer]                                     = js.undefined
+  var requestOCSP: js.UndefOr[Boolean]                                = js.undefined
+  var secureContext: js.UndefOr[SecureContext]                        = js.undefined
+}

--- a/app/current/src/main/scala/io/scalajs/nodejs/tls/SecureContextOptions.scala
+++ b/app/current/src/main/scala/io/scalajs/nodejs/tls/SecureContextOptions.scala
@@ -1,26 +1,28 @@
 package io.scalajs.nodejs.tls
 
 import io.scalajs.nodejs.buffer.Buffer
+import net.exoego.scalajs.types.util.Factory
 
 import scala.scalajs.js
 import scala.scalajs.js.|
 
-class SecureContextOptions(
-    var ca: js.UndefOr[SecureData] = js.undefined,
-    var cert: js.UndefOr[SecureData] = js.undefined,
-    var sigalgs: js.UndefOr[String] = js.undefined,
-    var ciphers: js.UndefOr[String] = js.undefined,
-    var clientCertEngine: js.UndefOr[String] = js.undefined,
-    var crl: js.UndefOr[SecureData] = js.undefined,
-    var dphram: js.UndefOr[String | Buffer] = js.undefined,
-    var ecdhCurve: js.UndefOr[String] = js.undefined,
-    var honorCipherOrder: js.UndefOr[Boolean] = js.undefined,
-    var key: js.UndefOr[SecureData] = js.undefined,
-    var maxVersion: js.UndefOr[String] = js.undefined,
-    var minVersion: js.UndefOr[String] = js.undefined,
-    var passphrase: js.UndefOr[String] = js.undefined,
-    var pfx: js.UndefOr[SecureData | js.Array[SecureDataObjectForm]] = js.undefined,
-    var secureOptions: js.UndefOr[Int] = js.undefined,
-    var secureProtocol: js.UndefOr[String] = js.undefined,
-    var sessionIdContext: js.UndefOr[String] = js.undefined
-) extends js.Object
+@Factory
+trait SecureContextOptions extends js.Object {
+  var ca: js.UndefOr[SecureData]                                   = js.undefined
+  var cert: js.UndefOr[SecureData]                                 = js.undefined
+  var sigalgs: js.UndefOr[String]                                  = js.undefined
+  var ciphers: js.UndefOr[String]                                  = js.undefined
+  var clientCertEngine: js.UndefOr[String]                         = js.undefined
+  var crl: js.UndefOr[SecureData]                                  = js.undefined
+  var dphram: js.UndefOr[String | Buffer]                          = js.undefined
+  var ecdhCurve: js.UndefOr[String]                                = js.undefined
+  var honorCipherOrder: js.UndefOr[Boolean]                        = js.undefined
+  var key: js.UndefOr[SecureData]                                  = js.undefined
+  var maxVersion: js.UndefOr[String]                               = js.undefined
+  var minVersion: js.UndefOr[String]                               = js.undefined
+  var passphrase: js.UndefOr[String]                               = js.undefined
+  var pfx: js.UndefOr[SecureData | js.Array[SecureDataObjectForm]] = js.undefined
+  var secureOptions: js.UndefOr[Int]                               = js.undefined
+  var secureProtocol: js.UndefOr[String]                           = js.undefined
+  var sessionIdContext: js.UndefOr[String]                         = js.undefined
+}

--- a/app/current/src/main/scala/io/scalajs/nodejs/tls/ServerOptions.scala
+++ b/app/current/src/main/scala/io/scalajs/nodejs/tls/ServerOptions.scala
@@ -1,41 +1,44 @@
 package io.scalajs.nodejs.tls
 
 import io.scalajs.nodejs.buffer.Buffer
+import net.exoego.scalajs.types.util.Factory
 
 import scala.scalajs.js
 import scala.scalajs.js.typedarray.{DataView, TypedArray}
 import scala.scalajs.js.|
 
-class ServerOptions(
-    var ALPNProtocols: js.UndefOr[
-      js.Array[String] | js.Array[TypedArray[_, _]] | js.Array[DataView] | TypedArray[_, _] | DataView
-    ] = js.undefined,
-    var enableTrace: js.UndefOr[Boolean] = js.undefined,
-    var handshakeTimeout: js.UndefOr[Int] = js.undefined,
-    var rejectUnauthorized: js.UndefOr[Boolean] = js.undefined,
-    var requestCert: js.UndefOr[Boolean] = js.undefined,
-    var sessionTimeout: js.UndefOr[Int] = js.undefined,
-    var SNICallback: js.UndefOr[js.Function2[String, js.Function2[io.scalajs.nodejs.Error, SecureContext, Any], Any]],
-    var ticketKeys: js.UndefOr[Buffer] = js.undefined,
-    // Options for net.createServers
-    var allowHalfOpen: js.UndefOr[Boolean] = js.undefined,
-    var pauseOnConnect: js.UndefOr[Boolean] = js.undefined,
-    // Options for tls.createSecureContext
-    var ca: js.UndefOr[SecureData] = js.undefined,
-    var cert: js.UndefOr[SecureData] = js.undefined,
-    var sigalgs: js.UndefOr[String] = js.undefined,
-    var ciphers: js.UndefOr[String] = js.undefined,
-    var clientCertEngine: js.UndefOr[String] = js.undefined,
-    var crl: js.UndefOr[SecureData] = js.undefined,
-    var dphram: js.UndefOr[String | Buffer] = js.undefined,
-    var ecdhCurve: js.UndefOr[String] = js.undefined,
-    var honorCipherOrder: js.UndefOr[Boolean] = js.undefined,
-    var key: js.UndefOr[SecureData] = js.undefined,
-    var maxVersion: js.UndefOr[String] = js.undefined,
-    var minVersion: js.UndefOr[String] = js.undefined,
-    var passphrase: js.UndefOr[String] = js.undefined,
-    var pfx: js.UndefOr[SecureData | js.Array[SecureDataObjectForm]] = js.undefined,
-    var secureOptions: js.UndefOr[Int] = js.undefined,
-    var secureProtocol: js.UndefOr[String] = js.undefined,
-    var sessionIdContext: js.UndefOr[String] = js.undefined
-) extends js.Object
+@Factory
+trait ServerOptions extends js.Object {
+  var ALPNProtocols: js.UndefOr[
+    js.Array[String] | js.Array[TypedArray[_, _]] | js.Array[DataView] | TypedArray[_, _] | DataView
+  ]                                           = js.undefined
+  var enableTrace: js.UndefOr[Boolean]        = js.undefined
+  var handshakeTimeout: js.UndefOr[Int]       = js.undefined
+  var rejectUnauthorized: js.UndefOr[Boolean] = js.undefined
+  var requestCert: js.UndefOr[Boolean]        = js.undefined
+  var sessionTimeout: js.UndefOr[Int]         = js.undefined
+  var SNICallback: js.UndefOr[js.Function2[String, js.Function2[io.scalajs.nodejs.Error, SecureContext, Any], Any]] =
+    js.undefined
+  var ticketKeys: js.UndefOr[Buffer] = js.undefined
+  // Options for net.createServers
+  var allowHalfOpen: js.UndefOr[Boolean]  = js.undefined
+  var pauseOnConnect: js.UndefOr[Boolean] = js.undefined
+  // Options for tls.createSecureContext
+  var ca: js.UndefOr[SecureData]                                   = js.undefined
+  var cert: js.UndefOr[SecureData]                                 = js.undefined
+  var sigalgs: js.UndefOr[String]                                  = js.undefined
+  var ciphers: js.UndefOr[String]                                  = js.undefined
+  var clientCertEngine: js.UndefOr[String]                         = js.undefined
+  var crl: js.UndefOr[SecureData]                                  = js.undefined
+  var dphram: js.UndefOr[String | Buffer]                          = js.undefined
+  var ecdhCurve: js.UndefOr[String]                                = js.undefined
+  var honorCipherOrder: js.UndefOr[Boolean]                        = js.undefined
+  var key: js.UndefOr[SecureData]                                  = js.undefined
+  var maxVersion: js.UndefOr[String]                               = js.undefined
+  var minVersion: js.UndefOr[String]                               = js.undefined
+  var passphrase: js.UndefOr[String]                               = js.undefined
+  var pfx: js.UndefOr[SecureData | js.Array[SecureDataObjectForm]] = js.undefined
+  var secureOptions: js.UndefOr[Int]                               = js.undefined
+  var secureProtocol: js.UndefOr[String]                           = js.undefined
+  var sessionIdContext: js.UndefOr[String]                         = js.undefined
+}

--- a/app/current/src/main/scala/io/scalajs/nodejs/tls/TLSSocket.scala
+++ b/app/current/src/main/scala/io/scalajs/nodejs/tls/TLSSocket.scala
@@ -3,6 +3,7 @@ package tls
 
 import com.thoughtworks.enableIf
 import io.scalajs.nodejs.buffer.Buffer
+import _root_.net.exoego.scalajs.types.util.Factory
 
 import scala.scalajs.js
 import scala.scalajs.js.annotation.JSImport
@@ -74,39 +75,50 @@ class TLSSocket(socket: stream.IDuplex, options: TLSSocketOptions = js.native) e
   def setMaxSendFragment(size: Int): Boolean = js.native
 }
 
-/**
-  * TLS Socket Options
-  * @param isServer           The SSL/TLS protocol is asymetrical, TLSSockets must know if they are to behave as a
-  *                           server or a client. If true the TLS socket will be instantiated as a server. Defaults to false.
-  * @param server             <net.Server> An optional net.Server instance.
-  * @param requestCert        Whether to authenticate the remote peer by requesting a certificate. Clients always
-  *                           request a server certificate. Servers (isServer is true) may optionally set requestCert
-  *                           to true to request a client certificate.
-  * @param rejectUnauthorized Optional, see tls.createServer()
-  * @param NPNProtocols       Optional, see tls.createServer()
-  * @param ALPNProtocols      Optional, see tls.createServer()
-  * @param SNICallback        Optional, see tls.createServer()
-  * @param session            <Buffer> An optional Buffer instance containing a TLS session.
-  * @param requestOCSP        <boolean> If true, specifies that the OCSP status request extension will be added to
-  *                           the client hello and an 'OCSPResponse' event will be emitted on the socket before
-  *                           establishing a secure communication
-  * @param secureContext      Optional TLS context object created with tls.createSecureContext(). If a secureContext
-  *                           is not provided, one will be created by calling tls.createSecureContext() with no options.
-  */
-class TLSSocketOptions(var enableTrace: js.UndefOr[Boolean] = js.undefined,
-                       var isServer: js.UndefOr[Boolean] = js.undefined,
-                       var server: js.UndefOr[net.Server] = js.undefined,
-                       var requestCert: js.UndefOr[Boolean] = js.undefined,
-                       var rejectUnauthorized: js.UndefOr[Boolean] = js.undefined,
-                       var NPNProtocols: js.UndefOr[Boolean] = js.undefined,
-                       var ALPNProtocols: js.UndefOr[ALPNProtocols] = js.undefined,
-                       var SNICallback: js.UndefOr[js.Function2[String, js.Function, Any]] = js.undefined,
-                       var session: js.UndefOr[Buffer] = js.undefined,
-                       var requestOCSP: js.UndefOr[Boolean] = js.undefined,
-                       var secureContext: js.UndefOr[SecureContext] = js.undefined
-) extends js.Object
+@Factory
+trait TLSSocketOptions extends js.Object {
+  var enableTrace: js.UndefOr[Boolean] = js.undefined
 
-class RenegotiateOptions(
-    var rejectUnauthorized: js.UndefOr[Boolean] = js.undefined,
-    var requestCert: js.UndefOr[Boolean] = js.undefined
-) extends js.Object
+  /** The SSL/TLS protocol is asymetrical, TLSSockets must know if they are to behave as a
+    * server or a client. If true the TLS socket will be instantiated as a server. Defaults to false.
+    */
+  var isServer: js.UndefOr[Boolean] = js.undefined
+
+  /** An optional net.Server instance. */
+  var server: js.UndefOr[net.Server] = js.undefined
+
+  /** Whether to authenticate the remote peer by requesting a certificate. Clients always request a server
+    * certificate. Servers (isServer is true) may optionally set requestCert o true to request a client certificate.
+    */
+  var requestCert: js.UndefOr[Boolean] = js.undefined
+
+  /** Optional, see tls.createServer()  */
+  var rejectUnauthorized: js.UndefOr[Boolean] = js.undefined
+
+  /** Optional, see tls.createServer()  */
+  var NPNProtocols: js.UndefOr[Boolean] = js.undefined
+
+  /** Optional, see tls.createServer()  */
+  var ALPNProtocols: js.UndefOr[ALPNProtocols] = js.undefined
+
+  /** Optional, see tls.createServer()  */
+  var SNICallback: js.UndefOr[js.Function2[String, js.Function, Any]] = js.undefined
+
+  /** An optional Buffer instance containing a TLS session. */
+  var session: js.UndefOr[Buffer] = js.undefined
+
+  /** If true, specifies that the OCSP status request extension will be added to the client hello and an
+    * 'OCSPResponse' event will be emitted on the socket before establishing a secure communication
+    */
+  var requestOCSP: js.UndefOr[Boolean] = js.undefined
+
+  /** Optional TLS context object created with tls.createSecureContext(). If a secureContext
+    * is not provided, one will be created by calling tls.createSecureContext() with no options.
+    */
+  var secureContext: js.UndefOr[SecureContext] = js.undefined
+}
+@Factory
+trait RenegotiateOptions extends js.Object {
+  var rejectUnauthorized: js.UndefOr[Boolean] = js.undefined
+  var requestCert: js.UndefOr[Boolean]        = js.undefined
+}

--- a/app/current/src/main/scala/io/scalajs/nodejs/url/UrlFormatOptions.scala
+++ b/app/current/src/main/scala/io/scalajs/nodejs/url/UrlFormatOptions.scala
@@ -1,18 +1,28 @@
 package io.scalajs.nodejs.url
 
+import net.exoego.scalajs.types.util.Factory
+
 import scala.scalajs.js
 
-/**
-  * URL Format Options
-  *
-  * @param auth     true if the serialized URL string should include the username and password, false otherwise. Defaults to true.
-  * @param fragment true if the serialized URL string should include the fragment, false otherwise. Defaults to true.
-  * @param search   true if the serialized URL string should include the search query, false otherwise. Defaults to true.
-  * @param unicode  true if Unicode characters appearing in the host component of the URL string should be encoded
-  *                 directly as opposed to being Punycode encoded. Defaults to false.
-  */
-class UrlFormatOptions(var auth: js.UndefOr[Boolean] = js.undefined,
-                       var fragment: js.UndefOr[Boolean] = js.undefined,
-                       var search: js.UndefOr[Boolean] = js.undefined,
-                       var unicode: js.UndefOr[Boolean] = js.undefined
-) extends js.Object
+@Factory
+trait UrlFormatOptions extends js.Object {
+
+  /** true if the serialized URL string should include the username and password, false otherwise. Defaults to true.
+    */
+  var auth: js.UndefOr[Boolean] = js.undefined
+
+  /** true if the serialized URL string should include the fragment, false otherwise.
+    * Defaults to true.
+    */
+  var fragment: js.UndefOr[Boolean] = js.undefined
+
+  /** true if the serialized URL string should include the search query, false otherwise.
+    * Defaults to true.
+    */
+  var search: js.UndefOr[Boolean] = js.undefined
+
+  /** true if Unicode characters appearing in the host component of the URL string should be encoded
+    * directly as opposed to being Punycode encoded. Defaults to false.
+    */
+  var unicode: js.UndefOr[Boolean] = js.undefined
+}

--- a/app/current/src/main/scala/io/scalajs/nodejs/util/InspectOptions.scala
+++ b/app/current/src/main/scala/io/scalajs/nodejs/util/InspectOptions.scala
@@ -1,40 +1,60 @@
 package io.scalajs.nodejs.util
 
+import com.thoughtworks.enableIf
+import net.exoego.scalajs.types.util.Factory
+
 import scala.scalajs.js
 import scala.scalajs.js.|
 
-/**
-  * Inspect Options
-  * @param showHidden     If true, the object's non-enumerable symbols and properties will be included in the
-  *                       formatted result. Defaults to false.
-  * @param depth          Specifies the number of times to recurse while formatting the object. This is useful
-  *                       for inspecting large complicated objects. Defaults to 2. To make it recurse indefinitely pass null.
-  * @param colors         If true, the output will be styled with ANSI color codes. Defaults to false. Colors are customizable,
-  *                       see Customizing util.inspect colors.
-  * @param customInspect  If false, then custom inspect(depth, opts) functions exported on the object being inspected
-  *                       will not be called. Defaults to true.
-  * @param showProxy      If true, then objects and functions that are Proxy objects will be introspected to show their
-  *                       target and handler objects. Defaults to false.
-  * @param maxArrayLength Specifies the maximum number of array and TypedArray elements to include when formatting.
-  *                       Defaults to 100. Set to null to show all array elements. Set to 0 or negative to show no array elements.
-  * @param breakLength    The length at which an object's keys are split across multiple lines. Set to Infinity to
-  *                       format an object as a single line. Defaults to 60 for legacy compatibility.
-  * @param compact        For Node.js v9.9.0+
-  * @param sorted         For Node.js v10.12.0+
-  * @param getters        For Node.js v11.5.0+
-  * @param maxStringLength Fot Node.js v14.0.0+ Specifies the maximum number of characters to include when formatting. Set to null or Infinity to show all elements.                       @
-  *
-  * @see [[https://nodejs.org/api/util.html#util_util_inspect_object_options]]
+/** @see [[https://nodejs.org/api/util.html#util_util_inspect_object_options]]
   */
-class InspectOptions(var showHidden: js.UndefOr[Boolean] = false,
-                     var depth: Int = 2,
-                     var colors: Boolean = false,
-                     var customInspect: Boolean = true,
-                     var showProxy: Boolean = false,
-                     var maxArrayLength: js.UndefOr[Int] = 100,
-                     var breakLength: Int = 80,
-                     var compact: js.UndefOr[Boolean | Int] = 3,
-                     var sorted: js.UndefOr[Boolean | js.Function2[String, String, Int]] = js.undefined,
-                     var getters: js.UndefOr[Boolean | String] = false,
-                     var maxStringLength: js.UndefOr[Int] = js.undefined
-) extends js.Object
+@Factory
+trait InspectOptions extends js.Object {
+
+  /** If true, the object's non-enumerable symbols and properties will be included in the
+    * formatted result. Defaults to false.
+    */
+  var showHidden: js.UndefOr[Boolean] = js.undefined
+
+  /** Specifies the number of times to recurse while formatting the object. This is useful
+    * for inspecting large complicated objects. Defaults to 2. To make it recurse indefinitely pass null.
+    */
+  var depth: js.UndefOr[Int] = js.undefined
+
+  /** If true, the output will be styled with ANSI color codes. Defaults to false. Colors are customizable,
+    * see Customizing util.inspect colors.
+    */
+  var colors: js.UndefOr[Boolean] = js.undefined
+
+  /** If false, then custom inspect(depth, opts) functions exported on the object being inspected
+    * will not be called. Defaults to true. */
+  var customInspect: js.UndefOr[Boolean] = js.undefined
+
+  /** If true, then objects and functions that are Proxy objects will be introspected to show their
+    * target and handler objects. Defaults to false.
+    */
+  var showProxy: js.UndefOr[Boolean] = js.undefined
+
+  /** Specifies the maximum number of array and TypedArray elements to include when formatting.
+    * Defaults to 100. Set to null to show all array elements. Set to 0 or negative to show no array elements.
+    */
+  var maxArrayLength: js.UndefOr[Int] = js.undefined
+
+  /** The length at which an object's keys are split across multiple lines. Set to Infinity to
+    * format an object as a single line. Defaults to 60 for legacy compatibility.
+    */
+  var breakLength: js.UndefOr[Int] = js.undefined
+
+  var compact: js.UndefOr[Boolean | Int] = js.undefined
+
+  var sorted: js.UndefOr[Boolean | js.Function2[String, String, Int]] = js.undefined
+
+  @enableIf(io.scalajs.nodejs.internal.CompilerSwitches.gteNodeJs12)
+  var getters: js.UndefOr[Boolean | String] = js.undefined
+
+  /** Fot Node.js v14.0.0+ Specifies the maximum number of characters to include when formatting.
+    * Set to null or Infinity to show all elements.
+    */
+  @enableIf(io.scalajs.nodejs.internal.CompilerSwitches.gteNodeJs14)
+  var maxStringLength: js.UndefOr[Int] = js.undefined
+}

--- a/app/current/src/main/scala/io/scalajs/nodejs/util/TextDecoder.scala
+++ b/app/current/src/main/scala/io/scalajs/nodejs/util/TextDecoder.scala
@@ -1,5 +1,7 @@
 package io.scalajs.nodejs.util
 
+import net.exoego.scalajs.types.util.Factory
+
 import scala.scalajs.js
 import scala.scalajs.js.annotation.JSImport
 import scala.scalajs.js.typedarray.{ArrayBuffer, ArrayBufferView}
@@ -16,6 +18,7 @@ class TextDecoder() extends js.Object {
   def decode(buffer: ArrayBuffer | ArrayBufferView, options: TextDecodeOptions = js.native): String = js.native
 }
 
-class TextDecodeOptions(
-    stream: js.UndefOr[Boolean] = js.undefined
-) extends js.Object {}
+@Factory
+trait TextDecodeOptions extends js.Object {
+  var stream: js.UndefOr[Boolean]
+}

--- a/app/current/src/main/scala/io/scalajs/nodejs/vm/Script.scala
+++ b/app/current/src/main/scala/io/scalajs/nodejs/vm/Script.scala
@@ -1,5 +1,7 @@
 package io.scalajs.nodejs.vm
 
+import net.exoego.scalajs.types.util.Factory
+
 import scala.scalajs.js
 import scala.scalajs.js.annotation.JSImport
 import scala.scalajs.js.typedarray.{DataView, Uint8Array}
@@ -44,28 +46,35 @@ class Script private[this] () extends js.Object {
   def runInThisContext(options: RunInContextOptions = js.native): Script = js.native
 }
 
-class ScriptOptions(var filename: js.UndefOr[String] = js.undefined,
-                    var lineOffset: js.UndefOr[Int] = js.undefined,
-                    var columnOffset: js.UndefOr[Int] = js.undefined,
-                    var cachedData: js.UndefOr[Uint8Array | DataView] = js.undefined,
-                    var produceCachedData: js.UndefOr[Boolean] = js.undefined,
-                    var importModuleDynamically: js.UndefOr[js.Function] = js.undefined
-) extends js.Object
+@Factory
+trait ScriptOptions extends js.Object {
+  var filename: js.UndefOr[String]                     = js.undefined
+  var lineOffset: js.UndefOr[Int]                      = js.undefined
+  var columnOffset: js.UndefOr[Int]                    = js.undefined
+  var cachedData: js.UndefOr[Uint8Array | DataView]    = js.undefined
+  var produceCachedData: js.UndefOr[Boolean]           = js.undefined
+  var importModuleDynamically: js.UndefOr[js.Function] = js.undefined
+}
 
-class RunInContextOptions(
-    var displayErrors: js.UndefOr[Boolean] = js.undefined,
-    var timeout: js.UndefOr[Int] = js.undefined,
-    var breakOnSigint: js.UndefOr[Boolean] = js.undefined
-) extends js.Object
+@Factory
+trait RunInContextOptions extends js.Object {
+  var displayErrors: js.UndefOr[Boolean] = js.undefined
+  var timeout: js.UndefOr[Int]           = js.undefined
+  var breakOnSigint: js.UndefOr[Boolean] = js.undefined
+}
 
-class RunInNewContextOptions(
-    var displayErrors: js.UndefOr[Boolean] = js.undefined,
-    var timeout: js.UndefOr[Int] = js.undefined,
-    var breakOnSigint: js.UndefOr[Boolean] = js.undefined,
-    var contextName: js.UndefOr[String] = js.undefined,
-    var contextOrigin: js.UndefOr[String] = js.undefined,
-    var contextCodeGeneration: js.UndefOr[CodeGeneration] = js.undefined
-) extends js.Object
+@Factory
+trait RunInNewContextOptions extends js.Object {
+  var displayErrors: js.UndefOr[Boolean]                = js.undefined
+  var timeout: js.UndefOr[Int]                          = js.undefined
+  var breakOnSigint: js.UndefOr[Boolean]                = js.undefined
+  var contextName: js.UndefOr[String]                   = js.undefined
+  var contextOrigin: js.UndefOr[String]                 = js.undefined
+  var contextCodeGeneration: js.UndefOr[CodeGeneration] = js.undefined
+}
 
-class CodeGeneration(var strings: js.UndefOr[Boolean] = js.undefined, var wasm: js.UndefOr[Boolean] = js.undefined)
-    extends js.Object
+@Factory
+trait CodeGeneration extends js.Object {
+  var strings: js.UndefOr[Boolean] = js.undefined
+  var wasm: js.UndefOr[Boolean]    = js.undefined
+}

--- a/app/current/src/main/scala/io/scalajs/nodejs/vm/VM.scala
+++ b/app/current/src/main/scala/io/scalajs/nodejs/vm/VM.scala
@@ -1,5 +1,7 @@
 package io.scalajs.nodejs.vm
 
+import net.exoego.scalajs.types.util.Factory
+
 import scala.scalajs.js
 import scala.scalajs.js.annotation.JSImport
 import scala.scalajs.js.typedarray.{DataView, Uint8Array}
@@ -84,45 +86,50 @@ trait VM extends js.Object {
 @JSImport("vm", JSImport.Namespace)
 object VM extends VM
 
-class CompileFunctionOptions(
-    var filename: js.UndefOr[String] = js.undefined,
-    var lineOffset: js.UndefOr[Int] = js.undefined,
-    var columnOffset: js.UndefOr[Int] = js.undefined,
-    var cachedData: js.UndefOr[Uint8Array | DataView] = js.undefined,
-    @deprecated("Use script.createCachedData", "Node.js v10")
-    var produceCachedData: js.UndefOr[Boolean] = js.undefined,
-    var parsingContext: js.UndefOr[js.Object] = js.undefined,
-    var contextExtensions: js.UndefOr[js.Array[js.Object]] = js.undefined
-) extends js.Object
+@Factory
+trait CompileFunctionOptions {
+  var filename: js.UndefOr[String]                  = js.undefined
+  var lineOffset: js.UndefOr[Int]                   = js.undefined
+  var columnOffset: js.UndefOr[Int]                 = js.undefined
+  var cachedData: js.UndefOr[Uint8Array | DataView] = js.undefined
+  @deprecated("Use script.createCachedData", "Node.js v10")
+  var produceCachedData: js.UndefOr[Boolean]             = js.undefined
+  var parsingContext: js.UndefOr[js.Object]              = js.undefined
+  var contextExtensions: js.UndefOr[js.Array[js.Object]] = js.undefined
+}
 
-class CreateContextOptions(
-    var name: js.UndefOr[String] = js.undefined,
-    var origin: js.UndefOr[String] = js.undefined,
-    var codeGeneration: js.UndefOr[CodeGeneration] = js.undefined
-) extends js.Object
+@Factory
+trait CreateContextOptions extends js.Object {
+  var name: js.UndefOr[String]                   = js.undefined
+  var origin: js.UndefOr[String]                 = js.undefined
+  var codeGeneration: js.UndefOr[CodeGeneration] = js.undefined
+}
 
-class VMRunInNewContextOptions(
-    var filename: js.UndefOr[String] = js.undefined,
-    var lineOffset: js.UndefOr[Int] = js.undefined,
-    var columnOffset: js.UndefOr[Int] = js.undefined,
-    var displayErrors: js.UndefOr[Boolean] = js.undefined,
-    var timeout: js.UndefOr[Int] = js.undefined,
-    var breakOnSigint: js.UndefOr[Boolean] = js.undefined,
-    var contextName: js.UndefOr[String] = js.undefined,
-    var contextOrigin: js.UndefOr[String] = js.undefined,
-    var contextCodeGeneration: js.UndefOr[CodeGeneration] = js.undefined,
-    var cachedData: js.UndefOr[Uint8Array | DataView] = js.undefined,
-    var produceCachedData: js.UndefOr[Boolean] = js.undefined,
-    var importModuleDynamically: js.UndefOr[js.Function] = js.undefined
-) extends js.Object
+@Factory
+trait VMRunInNewContextOptions extends js.Object {
+  var filename: js.UndefOr[String]                      = js.undefined
+  var lineOffset: js.UndefOr[Int]                       = js.undefined
+  var columnOffset: js.UndefOr[Int]                     = js.undefined
+  var displayErrors: js.UndefOr[Boolean]                = js.undefined
+  var timeout: js.UndefOr[Int]                          = js.undefined
+  var breakOnSigint: js.UndefOr[Boolean]                = js.undefined
+  var contextName: js.UndefOr[String]                   = js.undefined
+  var contextOrigin: js.UndefOr[String]                 = js.undefined
+  var contextCodeGeneration: js.UndefOr[CodeGeneration] = js.undefined
+  var cachedData: js.UndefOr[Uint8Array | DataView]     = js.undefined
+  var produceCachedData: js.UndefOr[Boolean]            = js.undefined
+  var importModuleDynamically: js.UndefOr[js.Function]  = js.undefined
+}
 
-class VMRunInContextOptions(var filename: js.UndefOr[String] = js.undefined,
-                            var lineOffset: js.UndefOr[Int] = js.undefined,
-                            var columnOffset: js.UndefOr[Int] = js.undefined,
-                            var displayErrors: js.UndefOr[Boolean] = js.undefined,
-                            var timeout: js.UndefOr[Int] = js.undefined,
-                            var breakOnSigint: js.UndefOr[Boolean] = js.undefined,
-                            var cachedData: js.UndefOr[Uint8Array | DataView] = js.undefined,
-                            var produceCachedData: js.UndefOr[Boolean] = js.undefined,
-                            var importModuleDynamically: js.UndefOr[js.Function] = js.undefined
-) extends js.Object
+@Factory
+trait VMRunInContextOptions extends js.Object {
+  var filename: js.UndefOr[String]                     = js.undefined
+  var lineOffset: js.UndefOr[Int]                      = js.undefined
+  var columnOffset: js.UndefOr[Int]                    = js.undefined
+  var displayErrors: js.UndefOr[Boolean]               = js.undefined
+  var timeout: js.UndefOr[Int]                         = js.undefined
+  var breakOnSigint: js.UndefOr[Boolean]               = js.undefined
+  var cachedData: js.UndefOr[Uint8Array | DataView]    = js.undefined
+  var produceCachedData: js.UndefOr[Boolean]           = js.undefined
+  var importModuleDynamically: js.UndefOr[js.Function] = js.undefined
+}

--- a/app/current/src/main/scala/io/scalajs/nodejs/worker_threads/WorkerOptions.scala
+++ b/app/current/src/main/scala/io/scalajs/nodejs/worker_threads/WorkerOptions.scala
@@ -1,15 +1,16 @@
 package io.scalajs.nodejs.worker_threads
 
-import io.scalajs.nodejs.process
+import net.exoego.scalajs.types.util.Factory
 
 import scala.scalajs.js
 
-class WorkerOptions(
-    var env: js.UndefOr[process.Environment] = js.undefined,
-    var eval: js.UndefOr[Boolean] = js.undefined,
-    var execArgv: js.UndefOr[js.Array[String]] = js.undefined,
-    var stdin: js.UndefOr[Boolean] = js.undefined,
-    var stdout: js.UndefOr[Boolean] = js.undefined,
-    var stderr: js.UndefOr[Boolean] = js.undefined,
-    var workerData: js.UndefOr[js.Any] = js.undefined
-) extends js.Object
+@Factory
+trait WorkerOptions extends js.Object {
+  var env: js.UndefOr[js.Object]             = js.undefined
+  var eval: js.UndefOr[Boolean]              = js.undefined
+  var execArgv: js.UndefOr[js.Array[String]] = js.undefined
+  var stdin: js.UndefOr[Boolean]             = js.undefined
+  var stdout: js.UndefOr[Boolean]            = js.undefined
+  var stderr: js.UndefOr[Boolean]            = js.undefined
+  var workerData: js.UndefOr[js.Any]         = js.undefined
+}

--- a/app/current/src/main/scala/io/scalajs/nodejs/zlib/BrotliOptions.scala
+++ b/app/current/src/main/scala/io/scalajs/nodejs/zlib/BrotliOptions.scala
@@ -1,10 +1,13 @@
 package io.scalajs.nodejs.zlib
 
+import net.exoego.scalajs.types.util.Factory
+
 import scala.scalajs.js
 
-class BrotliOptions(
-    var flush: js.UndefOr[Int] = js.undefined,
-    var finishFlush: js.UndefOr[Int] = js.undefined,
-    var chunkSize: js.UndefOr[Int] = js.undefined,
-    var params: js.UndefOr[js.Dictionary[js.Any]] = js.undefined
-) extends js.Object
+@Factory
+trait BrotliOptions extends js.Object {
+  var flush: js.UndefOr[Int]                    = js.undefined
+  var finishFlush: js.UndefOr[Int]              = js.undefined
+  var chunkSize: js.UndefOr[Int]                = js.undefined
+  var params: js.UndefOr[js.Dictionary[js.Any]] = js.undefined
+}

--- a/app/current/src/main/scala/io/scalajs/nodejs/zlib/CompressionOptions.scala
+++ b/app/current/src/main/scala/io/scalajs/nodejs/zlib/CompressionOptions.scala
@@ -1,27 +1,37 @@
 package io.scalajs.nodejs.zlib
 
+import net.exoego.scalajs.types.util.Factory
+
 import scala.scalajs.js
 import scala.scalajs.js.typedarray.{ArrayBuffer, DataView, TypedArray}
 import scala.scalajs.js.|
 
-/**
-  * Compression Options
-  * @param chunkSize   (default: 16*1024)
-  * @param dictionary  (deflate/inflate only, empty dictionary by default)
-  * @param flush       (default: zlib.Z_NO_FLUSH)
-  * @param finishFlush (default: zlib.Z_FINISH)
-  * @param level       (compression only)
-  * @param memLevel    (compression only)
-  * @param strategy    (compression only)
-  * @param windowBits  ???
-  */
-class CompressionOptions(var flush: js.UndefOr[CompressionFlush] = js.undefined,
-                         var finishFlush: js.UndefOr[CompressionFlush] = js.undefined,
-                         var chunkSize: js.UndefOr[Int] = js.undefined,
-                         var windowBits: js.UndefOr[Int] = js.undefined,
-                         var level: js.UndefOr[CompressionLevel] = js.undefined,
-                         var memLevel: js.UndefOr[CompressionLevel] = js.undefined,
-                         var strategy: js.UndefOr[CompressionStrategy] = js.undefined,
-                         var dictionary: js.UndefOr[TypedArray[_, _] | DataView | ArrayBuffer] = js.undefined,
-                         var info: js.UndefOr[Boolean] = js.undefined
-) extends js.Object
+@Factory
+trait CompressionOptions extends js.Object {
+  var flush: js.UndefOr[CompressionFlush] = js.undefined
+
+  var finishFlush: js.UndefOr[CompressionFlush] = js.undefined
+
+  var chunkSize: js.UndefOr[Int] = js.undefined
+
+  var windowBits: js.UndefOr[Int] = js.undefined
+
+  /**  (compression only)
+    */
+  var level: js.UndefOr[CompressionLevel] = js.undefined
+
+  /**  (compression only)
+    */
+  var memLevel: js.UndefOr[CompressionLevel] = js.undefined
+
+  /**  (compression only)
+    */
+  var strategy: js.UndefOr[CompressionStrategy] = js.undefined
+
+  /**
+    * deflate/inflate only, empty dictionary by default
+    */
+  var dictionary: js.UndefOr[TypedArray[_, _] | DataView | ArrayBuffer] = js.undefined
+
+  var info: js.UndefOr[Boolean] = js.undefined
+}

--- a/app/current/src/test/scala/io/scalajs/nodejs/fs/FsAsyncTest.scala
+++ b/app/current/src/test/scala/io/scalajs/nodejs/fs/FsAsyncTest.scala
@@ -27,12 +27,12 @@ class FsAsyncTest extends AsyncFunSpec with BeforeAndAfterEach {
     it("should support recursive-rmdir") {
       for {
         dirExistsBeforeMkdir <- Fs.existsFuture(dir)
-        _                    <- Fs.mkdirFuture(dir, new MkdirOptions(recursive = true))
+        _                    <- Fs.mkdirFuture(dir, MkdirOptions(recursive = true))
         _                    <- Fs.writeFileFuture("x.v12/hoge.txt", "foo")
         fileStat             <- Fs.statFuture("x.v12/hoge.txt")
         dirStat              <- Fs.statFuture(dir)
         dirExistsAfterMkdir  <- Fs.existsFuture(dir)
-        _                    <- Fs.rmdirFuture("x.v12", new RmdirOptions(recursive = true))
+        _                    <- Fs.rmdirFuture("x.v12", RmdirOptions(recursive = true))
         dirExistsAfterRmdir  <- Fs.existsFuture("x.v12")
       } yield {
         assert(!dirExistsBeforeMkdir)

--- a/app/nodejs-v10/src/test/scala/io/scalajs/nodejs/console_module/ConsoleTest.scala
+++ b/app/nodejs-v10/src/test/scala/io/scalajs/nodejs/console_module/ConsoleTest.scala
@@ -26,7 +26,7 @@ class ConsoleTest extends AnyFunSpec with BeforeAndAfterEach {
 
   it("have constructor(options) added in v10.0.0") {
     val console = new Console(
-      new ConsoleOptions(
+      ConsoleOptions(
         stdout = io.scalajs.nodejs.process.Process.stdout
       )
     )

--- a/app/nodejs-v10/src/test/scala/io/scalajs/nodejs/fs/FsAsyncTest.scala
+++ b/app/nodejs-v10/src/test/scala/io/scalajs/nodejs/fs/FsAsyncTest.scala
@@ -24,7 +24,7 @@ class FsAsyncTest extends AsyncFunSpec with BeforeAndAfterEach {
     it("should support recursive-mkdir") {
       for {
         dirExistsBeforeMkdir <- Fs.existsFuture(dir)
-        _                    <- Fs.mkdirFuture(dir, new MkdirOptions(recursive = true))
+        _                    <- Fs.mkdirFuture(dir, MkdirOptions(recursive = true))
         dirStat              <- Fs.statFuture(dir)
         dirExistsAfterMkdir  <- Fs.existsFuture(dir)
       } yield {

--- a/app/nodejs-v10/src/test/scala/io/scalajs/nodejs/fs/FsTest.scala
+++ b/app/nodejs-v10/src/test/scala/io/scalajs/nodejs/fs/FsTest.scala
@@ -56,7 +56,7 @@ class FsTest extends AsyncFunSpec {
       val file2 = s"${testResources}fileA2.txt"
       val file3 = s"${testResources}fileC2.txt"
 
-      val readable = Fs.createReadStream(file1, new FileInputOptions(encoding = "utf8"))
+      val readable = Fs.createReadStream(file1, FileInputOptions(encoding = "utf8"))
       val writable = Fs.createWriteStream(file2)
       readable.onData[String](chunk => {
         writable.end(chunk)

--- a/app/nodejs-v10/src/test/scala/io/scalajs/nodejs/fs/FsV8AsyncTest.scala
+++ b/app/nodejs-v10/src/test/scala/io/scalajs/nodejs/fs/FsV8AsyncTest.scala
@@ -70,7 +70,7 @@ class FsV8AsyncTest extends AsyncFunSpec with BeforeAndAfterEach {
     it("should support appendFileFuture") {
       for {
         _              <- Fs.appendFileFuture("x.AppendFile.txt", "yay")
-        _              <- Fs.appendFileFuture("x.AppendFile.sh", "echo 0", new FileAppendOptions(mode = Fs.constants.X_OK))
+        _              <- Fs.appendFileFuture("x.AppendFile.sh", "echo 0", FileAppendOptions(mode = Fs.constants.X_OK))
         defaultStat    <- Fs.statFuture("x.AppendFile.txt")
         executableStat <- Fs.statFuture("x.AppendFile.sh")
         _              <- Fs.unlinkFuture("x.AppendFile.txt")

--- a/app/nodejs-v10/src/test/scala/io/scalajs/nodejs/path/PathTest.scala
+++ b/app/nodejs-v10/src/test/scala/io/scalajs/nodejs/path/PathTest.scala
@@ -21,7 +21,7 @@ class PathTest extends AnyFunSpec {
     }
 
     it("supports format()") {
-      assert(Path.format(new PathObject(root = "/", base = "file.txt")) === "/file.txt")
+      assert(Path.format(PathObject(root = "/", base = "file.txt")) === "/file.txt")
     }
 
     it("supports isAbsolute()") {

--- a/app/nodejs-v10/src/test/scala/io/scalajs/nodejs/readline/ReadlineTest.scala
+++ b/app/nodejs-v10/src/test/scala/io/scalajs/nodejs/readline/ReadlineTest.scala
@@ -18,7 +18,7 @@ class ReadlineTest extends AsyncFunSpec {
       var lineNo  = 0
       val file    = "./package.json"
       val reader = Readline.createInterface(
-        new ReadlineOptions(
+        ReadlineOptions(
           input = Fs.createReadStream(file),
           output = Process.stdout,
           terminal = false
@@ -37,7 +37,7 @@ class ReadlineTest extends AsyncFunSpec {
 
     it("has REPL-like functionality") {
       val promise = Promise[Unit]()
-      val rl      = Readline.createInterface(new ReadlineOptions(input = Process.stdin, output = Process.stdout))
+      val rl      = Readline.createInterface(ReadlineOptions(input = Process.stdin, output = Process.stdout))
       rl.setPrompt("OHAI> ")
       rl.prompt()
 

--- a/app/nodejs-v10/src/test/scala/io/scalajs/nodejs/util/UtilTest.scala
+++ b/app/nodejs-v10/src/test/scala/io/scalajs/nodejs/util/UtilTest.scala
@@ -7,7 +7,7 @@ class UtilTest extends AnyFunSpec {
   it("have inspect object") {
     assert(Util.inspect !== null)
     assert(Util.inspect(js.Array(1, 2, 3)) === "[ 1, 2, 3 ]")
-    val inspectOptions = new InspectOptions(maxArrayLength = 1)
+    val inspectOptions = InspectOptions(maxArrayLength = 1)
     assert(Util.inspect(js.Array(1, 2, 3), inspectOptions) === "[ 1, ... 2 more items ]")
     assert(Util.inspect.defaultOptions !== null)
     assert(Util.inspect.styles !== null)
@@ -29,7 +29,7 @@ class UtilTest extends AnyFunSpec {
   it("have formatWithOptions added in v10.0.0") {
     assert(
       Util.formatWithOptions(
-        new InspectOptions(compact = true),
+        InspectOptions(compact = true),
         "See object %O",
         new js.Object {
           val foo: Int = 42

--- a/app/nodejs-v10/src/test/scala/io/scalajs/nodejs/zlib/ZlibTest.scala
+++ b/app/nodejs-v10/src/test/scala/io/scalajs/nodejs/zlib/ZlibTest.scala
@@ -12,7 +12,7 @@ class ZlibTest extends AnyFunSpec {
 
       for {
         compressed   <- Zlib.deflateFuture(original)
-        uncompressed <- Zlib.unzipFuture(compressed, new CompressionOptions(finishFlush = Zlib.Z_SYNC_FLUSH))
+        uncompressed <- Zlib.unzipFuture(compressed, CompressionOptions(finishFlush = Zlib.Z_SYNC_FLUSH))
       } {
         assert(original.compare(uncompressed) === 0)
       }


### PR DESCRIPTION
Closes #231
Closes #227 
Closes #203

This introdues source breaking changes at user site.
Users may need to just drop `new` keyword when instantiating `~Options`, `~Objects` or similar option-like JS objects.

