### PR TITLE
[vm] SecureContext is renamed to Context and now just an alias of js.Object

### DIFF
--- a/app/nodejs-v14/src/main/scala/io/scalajs/nodejs/vm/Script.scala
+++ b/app/nodejs-v14/src/main/scala/io/scalajs/nodejs/vm/Script.scala
@@ -26,8 +26,8 @@ class Script private[this] () extends js.Object {
     * @param options             the optional options
     * @example script.runInContext(contextifiedSandbox[, options])
     */
-  def runInContext(contextifiedSandbox: ScriptContext, options: RunInContextOptions): js.Any = js.native
-  def runInContext(contextifiedSandbox: ScriptContext): js.Any                               = js.native
+  def runInContext(contextifiedSandbox: Context, options: RunInContextOptions): js.Any = js.native
+  def runInContext(contextifiedSandbox: Context): js.Any                               = js.native
 
   /**
     * First contextifies the given sandbox, runs the compiled code contained by the vm.Script object within the created

--- a/app/nodejs-v14/src/main/scala/io/scalajs/nodejs/vm/ScriptContext.scala
+++ b/app/nodejs-v14/src/main/scala/io/scalajs/nodejs/vm/ScriptContext.scala
@@ -1,9 +1,0 @@
-package io.scalajs.nodejs.vm
-
-import scala.scalajs.js
-
-/**
-  * Script Context
-  */
-@js.native
-trait ScriptContext extends js.Object

--- a/app/nodejs-v14/src/main/scala/io/scalajs/nodejs/vm/SyntheticModule.scala
+++ b/app/nodejs-v14/src/main/scala/io/scalajs/nodejs/vm/SyntheticModule.scala
@@ -1,0 +1,17 @@
+package io.scalajs.nodejs.vm
+
+import net.exoego.scalajs.types.util.Factory
+
+import scala.scalajs.js
+
+class SyntheticModule protected () extends js.Object {
+  def this(exportNames: js.Array[String], evaluateCallback: js.Function, options: SyntheticModuleOptions) = this()
+  def this(exportNames: js.Array[String], evaluateCallback: js.Function) = this()
+
+}
+
+@Factory
+trait SyntheticModuleOptions extends js.Object {
+  var identifier: js.UndefOr[String] = js.undefined
+  var context: js.UndefOr[Context]   = js.undefined
+}

--- a/app/nodejs-v14/src/main/scala/io/scalajs/nodejs/vm/VM.scala
+++ b/app/nodejs-v14/src/main/scala/io/scalajs/nodejs/vm/VM.scala
@@ -33,9 +33,9 @@ trait VM extends js.Object {
     * @example vm.createContext([sandbox])
     * @since 0.11.7
     */
-  def createContext(sandbox: js.Object, options: CreateContextOptions): ScriptContext = js.native
-  def createContext(sandbox: js.Object): ScriptContext                                = js.native
-  def createContext(): ScriptContext                                                  = js.native
+  def createContext(sandbox: js.Object, options: CreateContextOptions): Context = js.native
+  def createContext(sandbox: js.Object): Context                                = js.native
+  def createContext(): Context                                                  = js.native
 
   /**
     * Returns true if the given sandbox object has been contextified using vm.createContext().
@@ -52,8 +52,8 @@ trait VM extends js.Object {
     * @param options             the optional options
     * @example script.runInContext(contextifiedSandbox[, options])
     */
-  def runInContext(code: String, contextifiedSandbox: ScriptContext, options: VMRunInContextOptions): js.Any = js.native
-  def runInContext(code: String, contextifiedSandbox: ScriptContext): js.Any                                 = js.native
+  def runInContext(code: String, contextifiedSandbox: Context, options: VMRunInContextOptions): js.Any = js.native
+  def runInContext(code: String, contextifiedSandbox: Context): js.Any                                 = js.native
 
   /**
     * First contextifies the given sandbox, runs the compiled code contained by the vm.Script object within the created

--- a/app/nodejs-v14/src/main/scala/io/scalajs/nodejs/vm/package.scala
+++ b/app/nodejs-v14/src/main/scala/io/scalajs/nodejs/vm/package.scala
@@ -1,0 +1,9 @@
+package io.scalajs.nodejs
+
+import scala.scalajs.js
+
+package object vm {
+  type Context = js.Object
+  @deprecated("Use js.Object instead", "v0.12.0")
+  type ScriptContext = js.Object
+}

--- a/app/nodejs-v14/src/main/scala/io/scalajs/nodejs/worker_threads/WorkerThreads.scala
+++ b/app/nodejs-v14/src/main/scala/io/scalajs/nodejs/worker_threads/WorkerThreads.scala
@@ -18,9 +18,8 @@ trait WorkerThreads extends js.Object {
   def workerData: js.Any = js.native
 
   @enableIf(io.scalajs.nodejs.internal.CompilerSwitches.gteNodeJs12)
-  def moveMessagePortToContext(port: MessagePort,
-                               contextifiedSandbox: io.scalajs.nodejs.vm.ScriptContext
-  ): MessagePort = js.native
+  def moveMessagePortToContext(port: MessagePort, contextifiedSandbox: io.scalajs.nodejs.vm.Context): MessagePort =
+    js.native
 
   @enableIf(io.scalajs.nodejs.internal.CompilerSwitches.gteNodeJs12)
   def receiveMessageOnPort(port: MessagePort): js.UndefOr[js.Object] = js.native


### PR DESCRIPTION
So any js.Object can be passed.

Part of #221 