### PR TITLE
"option" objects should extend js.Object & ClusterSettings.serialization should be optional

### DIFF
--- a/app/nodejs-v14/src/main/scala/io/scalajs/nodejs/child_process/SpawnSyncResult.scala
+++ b/app/nodejs-v14/src/main/scala/io/scalajs/nodejs/child_process/SpawnSyncResult.scala
@@ -6,7 +6,7 @@ import scala.scalajs.js
 import scala.scalajs.js.|
 
 @Factory
-trait SpawnSyncResult {
+trait SpawnSyncResult extends js.Object {
   var pid: Int
   var output: js.Array[Output]
   var stdout: Output

--- a/app/nodejs-v14/src/main/scala/io/scalajs/nodejs/cluster/ClusterSettings.scala
+++ b/app/nodejs-v14/src/main/scala/io/scalajs/nodejs/cluster/ClusterSettings.scala
@@ -35,7 +35,7 @@ trait ClusterSettings extends js.Object {
     * From Node.js v13.2.0, v12.16.0.
     */
   @enableIf(io.scalajs.nodejs.internal.CompilerSwitches.gteNodeJs12)
-  var serialization: String = js.native
+  var serialization: js.UndefOr[String] = js.native
 
   /** <Number> Sets the user identity of the process. (See setuid(2).) */
   var uid: UID = js.native

--- a/app/nodejs-v14/src/main/scala/io/scalajs/nodejs/crypto/DiffieHellmanOptions.scala
+++ b/app/nodejs-v14/src/main/scala/io/scalajs/nodejs/crypto/DiffieHellmanOptions.scala
@@ -4,7 +4,7 @@ import scala.scalajs.js
 import net.exoego.scalajs.types.util.Factory
 
 @Factory
-trait DiffieHellmanOptions {
+trait DiffieHellmanOptions extends js.Object {
   var privateKey: KeyObject
   var publicKey: KeyObject
 }

--- a/app/nodejs-v14/src/main/scala/io/scalajs/nodejs/fs/Fs.scala
+++ b/app/nodejs-v14/src/main/scala/io/scalajs/nodejs/fs/Fs.scala
@@ -1332,7 +1332,7 @@ trait FileAppendOptions extends js.Object {
 }
 
 @Factory
-trait FileEncodingOptions {
+trait FileEncodingOptions extends js.Object {
   var encoding: js.UndefOr[String] = js.undefined
 }
 
@@ -1400,7 +1400,7 @@ trait FileWatcherOptions extends js.Object {
 }
 
 @Factory
-trait StatOptions {
+trait StatOptions extends js.Object {
   var bigint: js.UndefOr[Boolean] = js.undefined
 }
 

--- a/app/nodejs-v14/src/main/scala/io/scalajs/nodejs/vm/VM.scala
+++ b/app/nodejs-v14/src/main/scala/io/scalajs/nodejs/vm/VM.scala
@@ -85,7 +85,7 @@ trait VM extends js.Object {
 object VM extends VM
 
 @Factory
-trait CompileFunctionOptions {
+trait CompileFunctionOptions extends js.Object {
   var filename: js.UndefOr[String]                  = js.undefined
   var lineOffset: js.UndefOr[Int]                   = js.undefined
   var columnOffset: js.UndefOr[Int]                 = js.undefined

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -16,7 +16,7 @@ object Dependencies {
   val app = Def.setting(
     Seq(
       scalaReflect.value,
-      "net.exoego"               %%% "scalajs-types-util" % "0.1.0",
+      "net.exoego"               %%% "scalajs-types-util" % "0.2.0",
       "org.scalatest"            %%% "scalatest"          % scalatestVersion % "test",
       "com.thoughtworks.enableIf" %% "enableif"           % "1.1.7"
     )

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -16,7 +16,7 @@ object Dependencies {
   val app = Def.setting(
     Seq(
       scalaReflect.value,
-      "net.exoego"               %%% "scalajs-types-util" % "0.2.0",
+      "net.exoego"               %%% "scalajs-types-util" % "0.2.1",
       "org.scalatest"            %%% "scalatest"          % scalatestVersion % "test",
       "com.thoughtworks.enableIf" %% "enableif"           % "1.1.7"
     )


### PR DESCRIPTION

> https://nodejs.org/dist/latest-v14.x/docs/api/cluster.html#cluster_cluster_settings
> serialization <string> Specify the kind of serialization used for sending messages between processes. Possible values are 'json' and 'advanced'. See Advanced Serialization for child_process for more details. Default: false.
