### PR TITLE
Drop Scala.js 0.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,8 +15,7 @@ env:
     - TRAVIS_NODE_VERSION="10.22.0"
 
 script:
-  - SCALAJS_VERSION="0.6.33" sbt ++$TRAVIS_SCALA_VERSION test
-  - SCALAJS_VERSION=""       sbt ++$TRAVIS_SCALA_VERSION test
+  - sbt ++$TRAVIS_SCALA_VERSION test
 
 install:
   - rm -rf ~/.nvm &&

--- a/project/MySettings.scala
+++ b/project/MySettings.scala
@@ -55,9 +55,6 @@ object MySettings {
   )
 
   lazy val commonScalaJsSettings = Seq(
-    scalacOptions ++= Seq("-P:scalajs:sjsDefinedByDefault").filter { _ =>
-      Option(System.getenv("SCALAJS_VERSION")).exists(_.startsWith("0.6."))
-    },
     scalaJSLinkerConfig ~= {
       _.withModuleKind(ModuleKind.CommonJSModule)
     },

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,7 +1,4 @@
-val scalaJSVersion =
-  Option(System.getenv("SCALAJS_VERSION")).filter(_.nonEmpty).getOrElse("1.1.1")
-
-addSbtPlugin("org.scala-js"      % "sbt-scalajs"   % scalaJSVersion)
+addSbtPlugin("org.scala-js"      % "sbt-scalajs"   % "1.1.1")
 addSbtPlugin("org.scalameta"     % "sbt-scalafmt"  % "2.4.0")
 addSbtPlugin("org.xerial.sbt"    % "sbt-sonatype"  % "3.9.4")
 addSbtPlugin("com.github.gseitz" % "sbt-release"   % "1.0.13")

--- a/script/release.sh
+++ b/script/release.sh
@@ -2,7 +2,4 @@
 
 cat ./version.sbt
 
-export SCALAJS_VERSION=0.6.33
-sbt clean +publishSigned sonatypeBundleUpload sonatypeReleaseAll
-unset SCALAJS_VERSION
 sbt clean +publishSigned sonatypeBundleUpload sonatypeReleaseAll


### PR DESCRIPTION
Scala.js 0.6.x reached EOL.
[v0.12.0](https://github.com/exoego/scala-js-nodejs/releases/tag/v0.12.0) was a final release for 0.6.x.
