### PR TITLE
[fs] Fs object do not extends FSConstant

### DIFF
--- a/app/nodejs-v14/src/main/scala/io/scalajs/nodejs/fs/Fs.scala
+++ b/app/nodejs-v14/src/main/scala/io/scalajs/nodejs/fs/Fs.scala
@@ -20,7 +20,7 @@ import scala.scalajs.js.|
   * or allow them to bubble up.
   */
 @js.native
-trait Fs extends js.Object with FSConstants {
+trait Fs extends js.Object {
 
   /** Returns an object containing commonly used constants for file system operations
     * @return an [[FSConstants object]] containing commonly used constants for file system operations


### PR DESCRIPTION
`Fs` object does not have constant members, like `S_IRUSR`.
Instead, constants are exposed via the `Fs.constants` members.

This mistake was made in the original source. https://github.com/scalajs-io/nodejs/blob/5dd8ad399c19acff68a6409208ca0ac1a29f50b3/app/lts/src/main/scala/io/scalajs/nodejs/fs/Fs.scala#L26