### PR TITLE
Add marker trait to Buffer

### DIFF
--- a/app/nodejs-v16/src/main/scala/io/scalajs/nodejs/buffer/Buffer.scala
+++ b/app/nodejs-v16/src/main/scala/io/scalajs/nodejs/buffer/Buffer.scala
@@ -1,6 +1,6 @@
 package io.scalajs.nodejs.buffer
 
-import com.thoughtworks.enableIf
+import net.exoego.facade.nodejs.BufferMaker
 
 import scala.scalajs.js
 import scala.scalajs.js.annotation.{JSBracketAccess, JSGlobal, JSImport}
@@ -11,7 +11,7 @@ import scala.scalajs.js.typedarray.{ArrayBuffer, DataView, TypedArray, Uint8Arra
   */
 @js.native
 @JSImport("buffer", "Buffer")
-class Buffer protected () extends Uint8Array( /* dummy to trick constructor */ -1) {
+class Buffer protected () extends Uint8Array( /* dummy to trick constructor */ -1) with BufferMaker {
 
   /** The index operator `[index]` can be used to get and set the octet at position `index` in `buf`. The values refer
     * to individual bytes, so the legal value range is between `0x00` and `0xFF` (hex) or `0` and `255` (decimal).

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -9,6 +9,7 @@ object Dependencies {
   val core = Def.setting(
     Seq(
       scalaReflect.value,
+      "net.exoego" %%% "scalajs-nodejs-markers" % "0.0.2",
       "org.scalatest" %%% "scalatest" % scalatestVersion % "test"
     )
   )


### PR DESCRIPTION
https://github.com/exoego/scalajs-nodejs-markers

`Buffer` inherit `net.exoego.facade.nodejs.BufferMarker` so `Buffer` can be used where `BufferMarker` is accepted in other library.